### PR TITLE
feat: windows build (v1.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,14 @@ jobs:
             ---
 
             full diff: https://github.com/mattenarle10/markamd/compare/v1.0.2...${{ github.ref_name }}
-          releaseDraft: false
+          # publish as a DRAFT so the matrix runners can both upload artifacts
+          # (including their per-platform latest.json entries) without racing
+          # to overwrite each other on the same live release. the publish-release
+          # job below flips the draft to public AFTER both legs complete + a
+          # consolidated latest.json with both `darwin-aarch64` and
+          # `windows-x86_64` platforms is in place.
+          # ref: https://v2.tauri.app/distribute/pipelines/github/
+          releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
 
@@ -158,13 +165,33 @@ jobs:
             echo "no dmg asset found — skipping rename"
           fi
 
+  # flip the draft release to public AFTER both matrix runners have finished
+  # uploading their artifacts + latest.json entries. this prevents the
+  # cross-platform race where each runner could overwrite the other's
+  # latest.json on a live release.
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "publishing draft release for ${{ github.ref_name }}"
+          gh release edit "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --latest
+
   # fires a Vercel deploy hook after a release publishes so markamd.vercel.app
   # rebuilds and picks up the new version automatically (no manual empty
   # commit needed). gracefully no-ops if the secret isn't set yet.
   # NOTE: GitHub Actions does not allow `secrets.*` in `if:` expressions —
   # they must be evaluated through env first (same pattern as HAS_APPLE_CERT).
   notify-site:
-    needs: build
+    needs: publish-release
     runs-on: ubuntu-latest
     env:
       HAS_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
             ### Windows
             download `marka.md_*-setup.exe` → run.
 
-            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. We're not code-signed on Windows yet — that's planned for v1.2. (Same dance macOS users did before our Apple Developer cert; nothing scary going on.)
+            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + open source — we don't sign Windows builds (paid certs aren't worth it for a free MIT project). Same one-time dance some macOS users did pre-notarization; nothing scary going on. The full source is on GitHub if you want to inspect or build it yourself.
 
             ## what's in this release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,30 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    # flag at job level for the cert-import step's `if:` condition.
-    # we DON'T put the actual cert material at job level — if we did,
-    # an empty APPLE_CERTIFICATE env var would leak into tauri-action,
-    # which sees the var as "set" and tries to `security import` empty
-    # data, hard-failing the bundle step.
+    strategy:
+      # don't kill the macOS build if Windows fails (or vice versa) — release
+      # still ships partial artifacts for users on the platform that built ok.
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            args: --target aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            args: ""
+          # - os: ubuntu-22.04                  (added in v1.1.1 — Linux branch)
+          #   target: x86_64-unknown-linux-gnu
+          #   args: ""
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     env:
+      # flag at job level for the cert-import step's `if:` condition.
+      # we DON'T put the actual cert material at job level — if we did,
+      # an empty APPLE_CERTIFICATE env var would leak into tauri-action,
+      # which sees the var as "set" and tries to `security import` empty
+      # data, hard-failing the bundle step.
       HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     steps:
       - name: checkout
@@ -31,7 +47,7 @@ jobs:
       - name: setup rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: cache cargo
         uses: actions/cache@v4
@@ -40,15 +56,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.os }}-cargo-
 
       - name: install dependencies
         run: bun install
 
-      - name: import apple cert + propagate signing env (if secrets present)
-        if: env.HAS_APPLE_CERT == 'true'
+      - name: import apple cert + propagate signing env (macOS only)
+        if: matrix.os == 'macos-latest' && env.HAS_APPLE_CERT == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -67,9 +83,9 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           rm /tmp/cert.p12
           # propagate the signing env to later steps so tauri-action can read it.
-          # this step is skipped when HAS_APPLE_CERT=false → these vars are never
-          # written → tauri-action's env contains no APPLE_* → Tauri auto-skips
-          # signing instead of running `codesign --sign ""` and failing.
+          # this step is skipped when HAS_APPLE_CERT=false or non-macOS → these
+          # vars are never written → tauri-action's env contains no APPLE_* →
+          # Tauri auto-skips signing instead of running `codesign --sign ""`.
           {
             echo "APPLE_SIGNING_IDENTITY=$APPLE_SIGNING_IDENTITY"
             echo "APPLE_ID=$APPLE_ID"
@@ -77,26 +93,32 @@ jobs:
             echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
           } >> "$GITHUB_ENV"
 
-      - name: build + release dmg
+      - name: build + release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Apple signing env injected by the cert-import step via $GITHUB_ENV
-          # (APPLE_SIGNING_IDENTITY / APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID).
-          # Tauri updater signing — signs the .app.tar.gz bundle + emits latest.json.
+          # (macOS only — Windows runner never sees these).
+          # Tauri updater signing — signs the bundle + emits latest.json. Set on
+          # both runners so macOS .app.tar.gz.sig and Windows .nsis.zip.sig are
+          # produced and the updater can verify upgrades cross-platform.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "marka.md ${{ github.ref_name }}"
           releaseBody: |
-            🐙 **marka.md ${{ github.ref_name }}** — notarized + auto-updating macOS app.
+            🐙 **marka.md ${{ github.ref_name }}** — now on **macOS + Windows**. (Linux landing in v1.1.1.)
 
             ## install
 
-            1. download the **`.dmg`** below
-            2. open it → drag **marka.md.app** into `/Applications`
-            3. open it. that's it.
+            ### macOS (notarized + auto-updating)
+            download `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
+
+            ### Windows
+            download `marka.md_*-setup.exe` → run.
+
+            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. We're not code-signed on Windows yet — that's planned for v1.2. (Same dance macOS users did before our Apple Developer cert; nothing scary going on.)
 
             ## what's in this release
 
@@ -112,17 +134,20 @@ jobs:
 
             ---
 
-            full diff: https://github.com/mattenarle10/markamd/compare/v0.1.0...${{ github.ref_name }}
+            full diff: https://github.com/mattenarle10/markamd/compare/v1.0.2...${{ github.ref_name }}
           releaseDraft: false
           prerelease: false
-          args: --target aarch64-apple-darwin
+          args: ${{ matrix.args }}
 
-      # tauri-action emits `marka.md_<version>_<arch>.dmg` by default — too wordy.
-      # rename to `marka.md.dmg` via GH API (pure metadata change, no re-upload).
+      # tauri-action emits `marka.md_<version>_<arch>.dmg` by default — too
+      # wordy. rename to `marka.md.dmg` via GH API (pure metadata change, no
+      # re-upload). macOS-only — Windows artifact names stay as
+      # `marka.md_<version>_x64-setup.exe` / `.msi` (Tauri convention).
       - name: rename dmg → marka.md.dmg
-        if: success()
+        if: matrix.os == 'macos-latest' && success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           set -e
           ASSET_ID=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq '.assets[] | select(.name | endswith(".dmg")) | .id' | head -1)

--- a/README.md
+++ b/README.md
@@ -38,18 +38,30 @@ works with claude, chatgpt, gemini, your local agent — anywhere that reads pla
 
 ## install
 
-### prebuilt `.dmg` (apple silicon)
-
 [download the latest release →](https://github.com/mattenarle10/markamd/releases/latest)
+
+### macOS (apple silicon, notarized)
+
+grab `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
+
+### Windows (10+, x64)
+
+grab `marka.md_*-setup.exe` → run.
+
+Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. Not code-signed on Windows yet — same dance macOS users did pre-notarization, nothing scary going on.
+
+### Linux
+
+coming in v1.1.1.
 
 ### from source
 
-requires bun (or npm), rust toolchain, xcode command line tools.
+requires bun (or npm), rust toolchain. on macOS: xcode command line tools. on Windows: MSVC build tools (Visual Studio installer → "Desktop development with C++"). on Linux: `libwebkit2gtk-4.1-dev libsoup-3.0-dev` + friends.
 
 ```sh
 bun install
 bun run tauri dev      # native window with hmr
-bun run tauri build    # produces .dmg under src-tauri/target/release/bundle/dmg/
+bun run tauri build    # produces .dmg (macOS) / -setup.exe (Windows) under src-tauri/target/release/bundle/
 ```
 
 ## keyboard

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ grab `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
 
 grab `marka.md_*-setup.exe` → run.
 
-Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. Not code-signed on Windows yet — same dance macOS users did pre-notarization, nothing scary going on.
+Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + MIT — we don't sign Windows builds (paid certs aren't worth it for a free OSS project). Full source is right here if you'd rather build it yourself.
 
 ### Linux
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.0.2"
+version = "1.1.0"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -17,20 +17,12 @@
         "height": 720,
         "minWidth": 640,
         "minHeight": 420,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
-        "transparent": true,
-        "dragDropEnabled": false,
-        "trafficLightPosition": {
-          "x": 16,
-          "y": 24
-        }
+        "dragDropEnabled": false
       }
     ],
     "security": {
       "csp": null
-    },
-    "macOSPrivateApi": true
+    }
   },
   "plugins": {
     "updater": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -3,6 +3,12 @@
   "app": {
     "windows": [
       {
+        "title": "marka.md",
+        "width": 1100,
+        "height": 720,
+        "minWidth": 640,
+        "minHeight": 420,
+        "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "transparent": true,

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "transparent": true,
+        "trafficLightPosition": {
+          "x": 16,
+          "y": 24
+        }
+      }
+    ],
+    "macOSPrivateApi": true
+  }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -574,12 +574,14 @@ export function App() {
     }
   }, [activePath, bumpTree, setActivePath]);
 
-  // ⌘⌥Z global keybinding for file-op undo (doesn't clash with editor ⌘Z).
-  // On macOS, Option modifies the produced character (⌥Z = Ω), so we match on
-  // e.code which reflects the physical key independent of modifiers.
+  // ⌘⌥Z (macOS) / Ctrl+Alt+Z (Windows/Linux) global keybinding for file-op undo
+  // (doesn't clash with editor ⌘Z / Ctrl+Z). Option/Alt modifies the produced
+  // character on macOS (⌥Z = Ω), so we match on e.code which reflects the
+  // physical key independent of modifiers.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.metaKey && e.altKey && !e.shiftKey && e.code === "KeyZ") {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.altKey && !e.shiftKey && e.code === "KeyZ") {
         e.preventDefault();
         void handleUndoFileOp();
       }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ const platformClass = /Mac|iPhone|iPad|iPod/i.test(ua)
     ? "is-windows"
     : /Linux/i.test(ua)
       ? "is-linux"
-      : "is-mac"; // default — matches our notarized primary target
+      : "is-unknown"; // no platform-specific chrome applied — safe default
 document.documentElement.classList.add(platformClass);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,19 @@ import ReactDOM from "react-dom/client";
 import { App } from "./app";
 import "./styles/globals.css";
 
+// platform class on <html> — lets CSS gate macOS-only chrome (traffic-light
+// padding) without runtime checks. set before first paint so layout never
+// flashes the wrong padding.
+const ua = navigator.userAgent;
+const platformClass = /Mac|iPhone|iPad|iPod/i.test(ua)
+  ? "is-mac"
+  : /Windows/i.test(ua)
+    ? "is-windows"
+    : /Linux/i.test(ua)
+      ? "is-linux"
+      : "is-mac"; // default — matches our notarized primary target
+document.documentElement.classList.add(platformClass);
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/styles/chrome/titlebar.css
+++ b/src/styles/chrome/titlebar.css
@@ -3,12 +3,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 12px 0 84px;
+  padding: 0 12px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
   height: var(--titlebar-h);
   -webkit-app-region: drag;
   user-select: none;
+}
+html.is-mac .mdv-titlebar {
+  padding: 0 12px 0 84px;
 }
 
 .mdv-titlebar__sep-v {


### PR DESCRIPTION
🐙 v1.1.0 — adds **Windows build** alongside macOS. Linux follows in v1.1.1.

## What changes

- **`src-tauri/tauri.conf.json`** strips macOS-only window keys (`titleBarStyle`, `hiddenTitle`, `trafficLightPosition`, `macOSPrivateApi`) — those would leave Windows with no chrome.
- **`src-tauri/tauri.macos.conf.json`** (NEW) restores them via Tauri's per-platform config merge.
- **`src/styles/chrome/titlebar.css`** — default padding is `0 12px`; `html.is-mac .mdv-titlebar` re-adds the 84px traffic-light reservation.
- **`src/main.tsx`** adds `is-mac` / `is-windows` / `is-linux` class to `<html>` before first paint.
- **`src/app.tsx`** ⌘⌥Z handler now also accepts Ctrl+Alt+Z.
- **`.github/workflows/release.yml`** — single macOS job → 2-OS matrix (macos-latest + windows-latest). Apple cert + dmg-rename steps gated to `matrix.os == 'macos-latest'`. Linux row commented out for v1.1.1.
- **`README.md`** — install section now covers macOS + Windows; Linux marked as v1.1.1.
- **versions** bumped to `1.1.0` in `package.json`, `Cargo.toml`, `tauri.conf.json`.

## What's NOT in this PR

- Windows code signing (deferred to v1.2 — paid cert). v1.1.0 ships unsigned with a SmartScreen install note.
- Linux runner (separate `feat/linux-build` branch coming next).
- Landing site dropdown — separate commit in `markamd-site` repo.

## Code review checklist

- [x] `tauri.conf.json` strip: only macOS-only keys removed
- [x] `tauri.macos.conf.json`: valid JSON, all 4 macOS keys restored
- [x] `release.yml` matrix: Apple cert step still gated to `macos-latest`, no leaking secrets to Windows runner, `fail-fast: false` so a Windows failure doesn't kill the macOS build
- [x] `main.tsx` boot script: runs once before mount, class applies before first paint
- [x] `titlebar.css` default works on Windows; `html.is-mac` override correct
- [x] `app.tsx:582`: keyboard guard now uses `mod = metaKey || ctrlKey`, doesn't break ⌘⌥Z on macOS
- [x] `bunx tsc --noEmit` clean
- [x] JSON validity verified on both tauri configs

## Test plan

1. After merge + tag `v1.1.0`, CI builds both macOS and Windows artifacts
2. Existing v1.0.2 macOS install → "check for updates" → applies v1.1.0 → relaunches
3. Windows laptop: install via `-setup.exe`, run keyboard checklist (Ctrl+K, Ctrl+S, Ctrl+Alt+Z file undo, etc.)
4. Landing site (separate repo) shows Windows as active platform in dropdown