### PR TITLE
feat(v1.3.0): linux build (AppImage + .deb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             args: ""
-          # - os: ubuntu-22.04                  (added in v1.1.1 — Linux branch)
-          #   target: x86_64-unknown-linux-gnu
-          #   args: ""
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            args: ""
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -59,6 +59,18 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
             ${{ matrix.os }}-cargo-
+
+      - name: install linux build deps
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
 
       - name: install dependencies
         run: bun install
@@ -108,7 +120,7 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "marka.md ${{ github.ref_name }}"
           releaseBody: |
-            🐙 **marka.md ${{ github.ref_name }}** — now on **macOS + Windows**. (Linux landing in v1.1.1.)
+            🐙 **marka.md ${{ github.ref_name }}** — now on **macOS · Windows · Linux** 🎉
 
             ## install
 
@@ -118,7 +130,12 @@ jobs:
             ### Windows
             download `marka.md_*-setup.exe` → run.
 
-            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + open source — we don't sign Windows builds (paid certs aren't worth it for a free MIT project). Same one-time dance some macOS users did pre-notarization; nothing scary going on. The full source is on GitHub if you want to inspect or build it yourself.
+            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + open source — we don't sign Windows builds (paid certs aren't worth it for a free MIT project). Full source on GitHub if you want to inspect or build it yourself.
+
+            ### Linux (x86_64)
+            download `marka.md_*.AppImage` → `chmod +x marka.md_*.AppImage` → run. self-contained, no install needed.
+
+            or grab `marka.md_*_amd64.deb` if you're on Debian/Ubuntu: `sudo dpkg -i marka.md_*_amd64.deb`.
 
             ## what's in this release
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ grab `marka.md_*-setup.exe` → run.
 
 Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + MIT — we don't sign Windows builds (paid certs aren't worth it for a free OSS project). Full source is right here if you'd rather build it yourself.
 
-### Linux
+### Linux (x86_64, AppImage)
 
-coming in v1.1.1.
+grab `marka.md_*.AppImage` → `chmod +x marka.md_*.AppImage` → run. self-contained, no install step needed.
+
+or grab the `.deb` if you're on Debian/Ubuntu: `sudo dpkg -i marka.md_*_amd64.deb`.
+
+no signing required on Linux — it's the freedom platform 🐧
 
 ### from source
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.2.0"
+version = "1.3.0"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
🐧 v1.3.0 — adds **Linux build** alongside macOS + Windows. marka.md is now tri-platform.

## What changes

- **`release.yml`**: matrix extended with `ubuntu-22.04` runner + new `install linux build deps` step (webkit2gtk-4.1 + soup-3.0 + javascriptcoregtk-4.1 + appindicator3 + librsvg2 + patchelf). releaseBody updated for tri-platform install instructions.
- **`README.md`**: Linux install section now real (AppImage + .deb), replaces "coming in v1.1.1" stub.
- **versions** bumped to `1.3.0` in `package.json`, `Cargo.toml`, `tauri.conf.json`.

## Companion landing site changes (separate commit, markamd-site repo)

- `Layout.astro` meta description: `"macOS + Windows"` → `"macOS, Windows, Linux"`
- `privacy.astro`: installer list adds Linux AppImage / .deb

## What's NOT in this PR

- No source code changes — Linux works because v1.1.0 already gated all macOS-only Rust code (`RunEvent::Opened`, `window-vibrancy`) with `#[cfg(target_os = "macos")]`, and v1.2.0's `use-shortcuts.ts` is platform-aware. This is purely a build pipeline ship.
- No Linux signing — Linux convention is unsigned packages (no equivalent to macOS notarization or Windows Authenticode). AppImage runs portable; .deb installs via dpkg.

## Test plan

1. After merge + tag `v1.3.0`, CI runs 3 matrix legs (macos + windows + ubuntu) → all artifacts in release
2. Existing v1.2.0 macOS install auto-updates to v1.3.0 cleanly
3. Windows install via setup.exe still works
4. Linux smoke test: download AppImage, chmod +x, run on Ubuntu (VM or friend)
5. Landing dropdown's Linux row auto-activates (no "soon" badge) when release publishes