### PR TITLE
fix(v1.3.2): window drag broken on macOS — missing acl permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.1"
+version = "1.3.2"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-set-fullscreen",
+    "core:window:allow-is-fullscreen",
+    "core:window:allow-toggle-maximize",
     "opener:default",
     "updater:default",
     "process:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/chrome/breadcrumb.tsx
+++ b/src/components/chrome/breadcrumb.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronRight, Copy, FilePlus2, FileText, FolderOpen, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
+import { startWindowDrag } from "@/lib";
 import exciteUrl from "@/assets/mascot/excite.png";
 
 export type SaveStatus = "idle" | "dirty" | "saving" | "saved";
@@ -55,7 +56,7 @@ export function Breadcrumb({
   const label = statusLabel(saveStatus);
 
   return (
-    <div className="mdv-breadcrumb" data-tauri-drag-region>
+    <div className="mdv-breadcrumb" data-tauri-drag-region onMouseDown={startWindowDrag}>
       <Button
         data-tooltip={sidebarOpen ? "hide sidebar (⌘B)" : "show sidebar (⌘B)"}
         aria-label={sidebarOpen ? "hide sidebar" : "show sidebar"}

--- a/src/components/chrome/status-bar.tsx
+++ b/src/components/chrome/status-bar.tsx
@@ -1,6 +1,6 @@
 import { CircleHelp } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
-import { formatTokens } from "@/lib";
+import { formatTokens, startWindowDrag } from "@/lib";
 
 type StatusBarProps = {
   fileName?: string;
@@ -19,7 +19,7 @@ export function StatusBar({
   onShowHelp,
 }: StatusBarProps) {
   return (
-    <footer className="mdv-statusbar" data-tauri-drag-region>
+    <footer className="mdv-statusbar" data-tauri-drag-region onMouseDown={startWindowDrag}>
       <div className="mdv-statusbar__group" data-tauri-drag-region>
         <span data-tauri-drag-region>{fileName ?? "untitled"}</span>
       </div>

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -13,7 +13,7 @@ import {
   Sun,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
-import { useThemeMode, useTransparency, type ThemeMode } from "@/lib";
+import { startWindowDrag, useThemeMode, useTransparency, type ThemeMode } from "@/lib";
 
 type TitleBarProps = {
   fileName?: string;
@@ -66,7 +66,7 @@ export function TitleBar({
             : Coffee;
 
   return (
-    <header className="mdv-titlebar" data-tauri-drag-region>
+    <header className="mdv-titlebar" data-tauri-drag-region onMouseDown={startWindowDrag}>
       <div className="mdv-titlebar__lead" data-tauri-drag-region />
 
       <div className="mdv-titlebar__center" data-tauri-drag-region>

--- a/src/components/files/sidebar.tsx
+++ b/src/components/files/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FolderOpen, Search, X } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
-import { basename, dirname, walkMarkdownFiles, type FileEntry, type FlatFileEntry } from "@/lib";
+import { basename, dirname, startWindowDrag, walkMarkdownFiles, type FileEntry, type FlatFileEntry } from "@/lib";
 import emptyTowerUrl from "@/assets/mascot/empty-m.png";
 import { FileTree, type NewEntry } from "./file-tree";
 
@@ -129,7 +129,7 @@ export function Sidebar({
       aria-hidden={!open}
     >
       <div className="mdv-sidebar__inner" style={{ width: `${width}px` }}>
-        <header className="mdv-sidebar__header" data-tauri-drag-region>
+        <header className="mdv-sidebar__header" data-tauri-drag-region onMouseDown={startWindowDrag}>
           <span className={`mdv-sidebar__title${rootPath ? "" : " is-empty"}`}>
             {rootPath ? basename(rootPath) : "no folder"}
           </span>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,6 +12,7 @@ export {
 export { STORAGE_KEYS, type StorageKey } from "./storage";
 export { buildCommands, type Command, type CommandActions } from "./commands";
 export { estimateTokens, formatTokens } from "./bundle";
+export { startWindowDrag } from "./window-drag";
 export {
   pickFolder,
   pickMarkdownFile,

--- a/src/lib/window-drag.ts
+++ b/src/lib/window-drag.ts
@@ -1,0 +1,22 @@
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const INTERACTIVE_SELECTOR =
+  "button, a, input, textarea, select, [role='button'], [role='menuitem'], [role='menuitemradio'], [role='menuitemcheckbox'], [contenteditable='true'], .mdv-titlebar__theme, .mdv-tooltip";
+
+// Belt-and-suspenders drag handler. data-tauri-drag-region works on most
+// macOS versions, but the "Overlay" title-bar style has documented caveats
+// around custom drag regions (Tauri 2 docs). This calls startDragging()
+// directly so window movement is guaranteed regardless of webkit quirks.
+export function startWindowDrag(e: ReactMouseEvent<HTMLElement>): void {
+  // Only primary (left) button
+  if (e.button !== 0) return;
+  const target = e.target as HTMLElement | null;
+  if (target?.closest(INTERACTIVE_SELECTOR)) return;
+  // Fire-and-forget — don't await, mousedown shouldn't be async-blocked.
+  void getCurrentWindow()
+    .startDragging()
+    .catch((err) => {
+      console.warn("marka.md: startDragging failed", err);
+    });
+}


### PR DESCRIPTION
## what

adds the missing Tauri 2 ACL permission \`core:window:allow-start-dragging\` so window drag actually works.

## why

\`core:default\` does **NOT** include start-dragging. without it:
- \`data-tauri-drag-region\` attribute silently fails (the IPC \`start_dragging\` command is blocked)
- the OS-level \`-webkit-app-region: drag\` CSS fallback worked on most macOS versions but not all

## changes

- **\`src-tauri/capabilities/default.json\`** — add 4 explicit window permissions:
  - \`core:window:allow-start-dragging\` (the actual fix)
  - \`core:window:allow-set-fullscreen\` + \`core:window:allow-is-fullscreen\` (⌃⌘F was also silently broken)
  - \`core:window:allow-toggle-maximize\` (enables native double-click-titlebar-to-zoom)
- **\`src/lib/window-drag.ts\`** — new shared helper \`startWindowDrag()\` calling \`getCurrentWindow().startDragging()\` directly. belt-and-suspenders fallback on \`onMouseDown\` for all 4 drag surfaces.
- **chrome components** — wire \`onMouseDown={startWindowDrag}\` on title-bar, breadcrumb, status-bar, sidebar header.
- **version bump** — 1.3.1 → 1.3.2 in 3 places.

## resolves

- closes #14 (reported by @yplaksyuk, macOS Apple Silicon)

## test plan

1. \`bun run tauri dev\`
2. drag titlebar → window moves ✅
3. drag breadcrumb / statusbar / sidebar header → window moves ✅
4. double-click titlebar → zooms (native) ✅
5. ⌃⌘F → fullscreen ✅
6. buttons still click (theme, reading mode, etc.) ✅

confirmed locally on macOS Apple Silicon.