### PR TITLE
feat(v1.3.3): platform-aware shortcut display + kanagawa/rose-pine/ayu themes + transparency slider + mermaid + delete

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# supporting marka.md
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [mattenarle10]
+# ko_fi: mattenarle10           # uncomment once you set up at https://ko-fi.com
+# buy_me_a_coffee: mattenarle10 # alternative — https://buymeacoffee.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,37 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          # need full history + tags so we can derive a per-release commit list
+          # via `git log <prev_tag>..<this_tag>` for the changelog.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: compute changelog since previous tag
+        id: changelog
+        shell: bash
+        run: |
+          set -e
+          # find the most recent tag BEFORE the one we're building. `git tag --sort`
+          # gives semver-ordered tags; we filter out the current ref and pick the next.
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${{ github.ref_name }}$" | head -1 || true)
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS="- first public release 🐙"
+            DIFF_URL=""
+          else
+            COMMITS=$(git log "$PREV_TAG..${{ github.ref_name }}" --pretty=format:'- %s' --no-merges --reverse)
+            if [ -z "$COMMITS" ]; then
+              COMMITS="- (no commit changes since $PREV_TAG — version bump only)"
+            fi
+            DIFF_URL="full diff: https://github.com/mattenarle10/markamd/compare/$PREV_TAG...${{ github.ref_name }}"
+          fi
+          echo "PREV_TAG=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "COMMITS<<COMMITS_EOF"
+            echo "$COMMITS"
+            echo "COMMITS_EOF"
+            echo "DIFF_URL=$DIFF_URL"
+          } >> "$GITHUB_OUTPUT"
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2
@@ -120,39 +151,29 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "marka.md ${{ github.ref_name }}"
           releaseBody: |
-            🐙 **marka.md ${{ github.ref_name }}** — now on **macOS · Windows · Linux** 🎉
+            🐙 **marka.md ${{ github.ref_name }}** — macOS · Windows · Linux
 
-            ## install
+            ## what changed
 
-            ### macOS (notarized + auto-updating)
-            download `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
+            ${{ steps.changelog.outputs.COMMITS }}
 
-            ### Windows
-            download `marka.md_*-setup.exe` → run.
-
-            Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + open source — we don't sign Windows builds (paid certs aren't worth it for a free MIT project). Full source on GitHub if you want to inspect or build it yourself.
-
-            ### Linux (x86_64) — pick your flavor 🐧
-
-            - **`marka.md_*.AppImage`** — works on any distro: `chmod +x marka.md_*.AppImage` → run. self-contained, no install.
-            - **`marka.md_*_amd64.deb`** — Debian / Ubuntu / Mint / Pop!_OS: `sudo dpkg -i marka.md_*_amd64.deb`
-            - **`marka.md-*.x86_64.rpm`** — Fedora / RHEL / Rocky / openSUSE: `sudo dnf install marka.md-*.x86_64.rpm`
-
-            ## what's in this release
-
-            see the always-fresh changelog → https://markamd.vercel.app/changelog
-
-            ## thanks 🐙
-
-            if marka.md is useful, **[star the repo](https://github.com/mattenarle10/markamd)** — helps a lot.
-
-            questions / feedback / bugs → [open an issue](https://github.com/mattenarle10/markamd/issues)
-
-            — matt enarle · [mattenarle.com](https://mattenarle.com)
+            ${{ steps.changelog.outputs.DIFF_URL }}
 
             ---
 
-            full diff: https://github.com/mattenarle10/markamd/compare/v1.0.2...${{ github.ref_name }}
+            ## install
+
+            **macOS** (notarized + auto-updating): `marka.md.dmg` → drag to `/Applications`
+            **Windows**: `marka.md_*-setup.exe` → run (SmartScreen → "More info" → "Run anyway")
+            **Linux** 🐧: pick `.AppImage` (any distro), `.deb` (Debian/Ubuntu), or `.rpm` (Fedora/RHEL)
+
+            existing users on auto-update get this on next launch.
+
+            ## links
+
+            • [all releases](https://markamd.vercel.app/changelog) · [site](https://markamd.vercel.app) · [feedback](https://markamd.vercel.app/feedback) · [star the repo ⭐](https://github.com/mattenarle10/markamd)
+
+            — matt enarle · [mattenarle.com](https://mattenarle.com)
           # publish as a DRAFT so the matrix runners can both upload artifacts
           # (including their per-platform latest.json entries) without racing
           # to overwrite each other on the same live release. the publish-release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.2"
+version = "1.3.3"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,7 @@
 @import "./styles/shared/menu.css";
 @import "./styles/shared/kbd.css";
 @import "./styles/shared/toast.css";
+@import "./styles/shared/transparency.css";
 @import "./styles/chrome/titlebar.css";
 @import "./styles/chrome/breadcrumb.css";
 @import "./styles/chrome/statusbar.css";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -683,13 +683,39 @@ export function App() {
     }
     items.push("divider");
     items.push({
-      label: "delete",
-      disabled: true,
-      hint: "soon",
-      onSelect: () => {},
+      label: isDir ? "delete folder" : "delete",
+      destructive: true,
+      onSelect: () => {
+        const name = basename(path);
+        const msg = isDir
+          ? `delete folder "${name}" and everything inside it?\n\nthis cannot be undone.`
+          : `delete "${name}"?\n\nthis cannot be undone.`;
+        if (!window.confirm(msg)) return;
+        void (async () => {
+          try {
+            await removeEntry(path, isDir);
+            // if the deleted file was active, clear the editor
+            if (!isDir && activePath === path) {
+              setActivePath(null);
+              setSource(DEMO_MARKDOWN);
+              setSavedContent(DEMO_MARKDOWN);
+            }
+            // if the deleted folder contained the active file, clear too
+            if (isDir && activePath && activePath.startsWith(path + "/")) {
+              setActivePath(null);
+              setSource(DEMO_MARKDOWN);
+              setSavedContent(DEMO_MARKDOWN);
+            }
+            bumpTree();
+          } catch (err) {
+            console.error("marka.md: delete failed", err);
+            setLoadError({ message: `couldn't delete: ${String(err)}` });
+          }
+        })();
+      },
     });
     return items;
-  }, [contextMenu]);
+  }, [contextMenu, activePath, setActivePath, bumpTree]);
 
   // OS "Open With → marka.md" from Finder — Rust emits marka:open-file
   useEffect(() => {

--- a/src/components/chrome/breadcrumb.tsx
+++ b/src/components/chrome/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronRight, Copy, FilePlus2, FileText, FolderOpen, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
-import { startWindowDrag } from "@/lib";
+import { shortcutLabel, startWindowDrag } from "@/lib";
 import exciteUrl from "@/assets/mascot/excite.png";
 
 export type SaveStatus = "idle" | "dirty" | "saving" | "saved";
@@ -58,7 +58,7 @@ export function Breadcrumb({
   return (
     <div className="mdv-breadcrumb" data-tauri-drag-region onMouseDown={startWindowDrag}>
       <Button
-        data-tooltip={sidebarOpen ? "hide sidebar (⌘B)" : "show sidebar (⌘B)"}
+        data-tooltip={shortcutLabel(sidebarOpen ? "hide sidebar (⌘B)" : "show sidebar (⌘B)")}
         aria-label={sidebarOpen ? "hide sidebar" : "show sidebar"}
         onClick={onToggleSidebar}
         icon={
@@ -120,7 +120,7 @@ export function Breadcrumb({
           <button
             type="button"
             className={`mdv-copybtn${copyPulse ? " is-copied" : ""}`}
-            data-tooltip={copyPulse ? "copied!" : "copy markdown (⌘⇧C)"}
+            data-tooltip={copyPulse ? "copied!" : shortcutLabel("copy markdown (⌘⇧C)")}
             aria-label={copyPulse ? "copied" : "copy markdown"}
             onClick={onCopyMarkdown}
           >
@@ -133,19 +133,19 @@ export function Breadcrumb({
           </button>
         ) : null}
         <Button
-          data-tooltip="new file (⌘N)"
+          data-tooltip={shortcutLabel("new file (⌘N)")}
           aria-label="new file"
           onClick={onNewFile}
           icon={<Icon icon={FilePlus2} size={13} strokeWidth={1.5} />}
         />
         <Button
-          data-tooltip="open file (⌘O)"
+          data-tooltip={shortcutLabel("open file (⌘O)")}
           aria-label="open file"
           onClick={onOpenFile}
           icon={<Icon icon={FileText} size={13} strokeWidth={1.5} />}
         />
         <Button
-          data-tooltip="open folder (⌘⇧O)"
+          data-tooltip={shortcutLabel("open folder (⌘⇧O)")}
           aria-label="open folder"
           onClick={onOpenFolder}
           icon={<Icon icon={FolderOpen} size={13} strokeWidth={1.5} />}

--- a/src/components/chrome/status-bar.tsx
+++ b/src/components/chrome/status-bar.tsx
@@ -1,6 +1,6 @@
 import { CircleHelp } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
-import { formatTokens, startWindowDrag } from "@/lib";
+import { formatTokens, shortcutLabel, startWindowDrag } from "@/lib";
 
 type StatusBarProps = {
   fileName?: string;
@@ -33,7 +33,7 @@ export function StatusBar({
         <span>{minutes} min read</span>
         <Button
           className="mdv-statusbar__help"
-          data-tooltip="how to use (⌘/)"
+          data-tooltip={shortcutLabel("how to use (⌘/)")}
           aria-label="how to use"
           onClick={onShowHelp}
           icon={<Icon icon={CircleHelp} size={12} strokeWidth={1.5} />}

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -61,7 +61,8 @@ export function TitleBar({
   const [menuOpen, setMenuOpen] = useState(false);
   const themeAnchorRef = useRef<HTMLDivElement>(null);
   // hover = preview only (DOM-level, no storage write).
-  // mouse-leave or menu close = revert to stored theme.
+  // moving between items keeps the preview (no flash).
+  // mouse-leave the ENTIRE menu OR popover close = revert to stored.
   // click = commit (setMode → writes storage + applies).
   const hoverTimer = useRef<number | null>(null);
   const resolveThemeForPreview = (value: ThemeMode): Theme =>
@@ -73,11 +74,16 @@ export function TitleBar({
       hoverTimer.current = null;
     }, 60);
   };
-  const cancelPreview = () => {
+  const cancelHoverTimer = () => {
+    // cancel a PENDING preview without reverting — used when cursor leaves an
+    // item but is still inside the menu (moving to another item).
     if (hoverTimer.current !== null) {
       window.clearTimeout(hoverTimer.current);
       hoverTimer.current = null;
     }
+  };
+  const cancelPreview = () => {
+    cancelHoverTimer();
     previewTheme(null);
   };
 
@@ -156,7 +162,7 @@ export function TitleBar({
             }}
             anchorRef={themeAnchorRef}
           >
-            <div className="mdv-menu">
+            <div className="mdv-menu" onMouseLeave={cancelPreview}>
               <div className="mdv-menu__label">theme</div>
               {THEME_CHOICES.map((c) => {
                 const active = mode === c.value;
@@ -166,9 +172,9 @@ export function TitleBar({
                     type="button"
                     className={`mdv-menu__item${active ? " is-active" : ""}`}
                     onMouseEnter={() => previewOnHover(c.value)}
-                    onMouseLeave={cancelPreview}
+                    onMouseLeave={cancelHoverTimer}
                     onFocus={() => previewOnHover(c.value)}
-                    onBlur={cancelPreview}
+                    onBlur={cancelHoverTimer}
                     onClick={() => {
                       // click commits immediately + closes menu
                       cancelPreview();

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -17,7 +17,7 @@ import {
   Waves,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
-import { shortcutLabel, startWindowDrag, useThemeMode, useTransparency, type ThemeMode } from "@/lib";
+import { getSystemTheme, previewTheme, shortcutLabel, startWindowDrag, useThemeMode, useTransparency, type Theme, type ThemeMode } from "@/lib";
 
 type TitleBarProps = {
   fileName?: string;
@@ -60,21 +60,25 @@ export function TitleBar({
   const { opacity, on: transparent, set: setTransparency } = useTransparency();
   const [menuOpen, setMenuOpen] = useState(false);
   const themeAnchorRef = useRef<HTMLDivElement>(null);
-  // hover-to-preview-theme: a tiny debounce avoids ping-pong as the cursor
-  // slides past menu items. Holding still over a theme for ~60ms applies it.
+  // hover = preview only (DOM-level, no storage write).
+  // mouse-leave or menu close = revert to stored theme.
+  // click = commit (setMode → writes storage + applies).
   const hoverTimer = useRef<number | null>(null);
-  const applyThemeOnHover = (value: ThemeMode) => {
+  const resolveThemeForPreview = (value: ThemeMode): Theme =>
+    value === "system" ? getSystemTheme() : value;
+  const previewOnHover = (value: ThemeMode) => {
     if (hoverTimer.current !== null) window.clearTimeout(hoverTimer.current);
     hoverTimer.current = window.setTimeout(() => {
-      setMode(value);
+      previewTheme(resolveThemeForPreview(value));
       hoverTimer.current = null;
     }, 60);
   };
-  const cancelHoverApply = () => {
+  const cancelPreview = () => {
     if (hoverTimer.current !== null) {
       window.clearTimeout(hoverTimer.current);
       hoverTimer.current = null;
     }
+    previewTheme(null);
   };
 
   // ActiveIcon is the resolved theme's icon (single source of truth: THEME_CHOICES).
@@ -144,7 +148,14 @@ export function TitleBar({
             onClick={() => setMenuOpen((v) => !v)}
             icon={<Icon icon={ActiveIcon} size={14} strokeWidth={1.5} />}
           />
-          <Popover open={menuOpen} onClose={() => setMenuOpen(false)} anchorRef={themeAnchorRef}>
+          <Popover
+            open={menuOpen}
+            onClose={() => {
+              cancelPreview();
+              setMenuOpen(false);
+            }}
+            anchorRef={themeAnchorRef}
+          >
             <div className="mdv-menu">
               <div className="mdv-menu__label">theme</div>
               {THEME_CHOICES.map((c) => {
@@ -154,13 +165,13 @@ export function TitleBar({
                     key={c.value}
                     type="button"
                     className={`mdv-menu__item${active ? " is-active" : ""}`}
-                    onMouseEnter={() => applyThemeOnHover(c.value)}
-                    onMouseLeave={cancelHoverApply}
-                    onFocus={() => applyThemeOnHover(c.value)}
-                    onBlur={cancelHoverApply}
+                    onMouseEnter={() => previewOnHover(c.value)}
+                    onMouseLeave={cancelPreview}
+                    onFocus={() => previewOnHover(c.value)}
+                    onBlur={cancelPreview}
                     onClick={() => {
                       // click commits immediately + closes menu
-                      cancelHoverApply();
+                      cancelPreview();
                       setMode(c.value);
                       setMenuOpen(false);
                     }}

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import {
   BookOpen,
   Check,
+  Cloud,
   Coffee,
   Copy,
   FileDown,
@@ -12,6 +13,7 @@ import {
   Moon,
   Sparkles,
   Sun,
+  Sunset,
   Waves,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
@@ -36,11 +38,12 @@ const THEME_CHOICES: ThemeChoice[] = [
   { value: "system", label: "system", icon: Monitor },
   { value: "latte", label: "latte", icon: Sun },
   { value: "matcha", label: "matcha", icon: Leaf },
-  { value: "frappe", label: "frappé", icon: Coffee },
+  { value: "frappe", label: "frappé", icon: Cloud },
   { value: "macchiato", label: "macchiato", icon: Coffee },
   { value: "mocha", label: "mocha", icon: Moon },
   { value: "kanagawa", label: "kanagawa", icon: Waves },
   { value: "rose-pine", label: "rose pine", icon: Flower2 },
+  { value: "ayu", label: "ayu", icon: Sunset },
 ];
 
 export function TitleBar({
@@ -54,24 +57,16 @@ export function TitleBar({
   onExportPdf,
 }: TitleBarProps) {
   const { mode, resolved, setMode } = useThemeMode();
-  const { on: transparent, set: setTransparent } = useTransparency();
+  const { opacity, on: transparent, set: setTransparency } = useTransparency();
   const [menuOpen, setMenuOpen] = useState(false);
   const themeAnchorRef = useRef<HTMLDivElement>(null);
 
+  // ActiveIcon is the resolved theme's icon (single source of truth: THEME_CHOICES).
+  // Avoids drift when adding new themes — add one entry to THEME_CHOICES, done.
   const ActiveIcon =
     mode === "system"
       ? Monitor
-      : resolved === "latte"
-        ? Sun
-        : resolved === "matcha"
-          ? Leaf
-          : resolved === "mocha"
-            ? Moon
-            : resolved === "kanagawa"
-              ? Waves
-              : resolved === "rose-pine"
-                ? Flower2
-                : Coffee;
+      : (THEME_CHOICES.find((c) => c.value === resolved)?.icon ?? Coffee);
 
   return (
     <header className="mdv-titlebar" data-tauri-drag-region onMouseDown={startWindowDrag}>
@@ -163,19 +158,31 @@ export function TitleBar({
                 );
               })}
               <div className="mdv-menu__divider" aria-hidden />
-              <button
-                type="button"
-                className={`mdv-menu__item${transparent ? " is-active" : ""}`}
-                onClick={() => setTransparent(!transparent)}
-                role="menuitemcheckbox"
-                aria-checked={transparent}
-              >
-                <span className="mdv-menu__item-icon">
+              <div className={`mdv-menu__slider${transparent ? " is-active" : ""}`}>
+                <span className="mdv-menu__slider-icon" aria-hidden>
                   <Icon icon={Sparkles} size={14} strokeWidth={1.5} />
                 </span>
-                <span className="mdv-menu__item-label">transparency</span>
-                <span className={`mdv-menu__switch${transparent ? " is-on" : ""}`} aria-hidden />
-              </button>
+                <span className="mdv-menu__slider-label">transparency</span>
+                <span className="mdv-menu__slider-value" aria-hidden>
+                  {opacity >= 100 ? "off" : `${100 - opacity}%`}
+                </span>
+                <input
+                  type="range"
+                  className="mdv-menu__slider-input"
+                  min={0}
+                  max={100}
+                  step={1}
+                  /* invert: slider RIGHT = more transparent (lower opacity)
+                     so the value-label "% transparent" maps left→right cleanly. */
+                  value={100 - opacity}
+                  onChange={(e) => setTransparency(100 - Number(e.target.value))}
+                  aria-label="window transparency"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={100 - opacity}
+                  aria-valuetext={`${100 - opacity} percent transparent`}
+                />
+              </div>
             </div>
           </Popover>
         </div>

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -60,6 +60,22 @@ export function TitleBar({
   const { opacity, on: transparent, set: setTransparency } = useTransparency();
   const [menuOpen, setMenuOpen] = useState(false);
   const themeAnchorRef = useRef<HTMLDivElement>(null);
+  // hover-to-preview-theme: a tiny debounce avoids ping-pong as the cursor
+  // slides past menu items. Holding still over a theme for ~60ms applies it.
+  const hoverTimer = useRef<number | null>(null);
+  const applyThemeOnHover = (value: ThemeMode) => {
+    if (hoverTimer.current !== null) window.clearTimeout(hoverTimer.current);
+    hoverTimer.current = window.setTimeout(() => {
+      setMode(value);
+      hoverTimer.current = null;
+    }, 60);
+  };
+  const cancelHoverApply = () => {
+    if (hoverTimer.current !== null) {
+      window.clearTimeout(hoverTimer.current);
+      hoverTimer.current = null;
+    }
+  };
 
   // ActiveIcon is the resolved theme's icon (single source of truth: THEME_CHOICES).
   // Avoids drift when adding new themes — add one entry to THEME_CHOICES, done.
@@ -138,7 +154,13 @@ export function TitleBar({
                     key={c.value}
                     type="button"
                     className={`mdv-menu__item${active ? " is-active" : ""}`}
+                    onMouseEnter={() => applyThemeOnHover(c.value)}
+                    onMouseLeave={cancelHoverApply}
+                    onFocus={() => applyThemeOnHover(c.value)}
+                    onBlur={cancelHoverApply}
                     onClick={() => {
+                      // click commits immediately + closes menu
+                      cancelHoverApply();
                       setMode(c.value);
                       setMenuOpen(false);
                     }}

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -5,15 +5,17 @@ import {
   Coffee,
   Copy,
   FileDown,
+  Flower2,
   Leaf,
   Minimize2,
   Monitor,
   Moon,
   Sparkles,
   Sun,
+  Waves,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
-import { startWindowDrag, useThemeMode, useTransparency, type ThemeMode } from "@/lib";
+import { shortcutLabel, startWindowDrag, useThemeMode, useTransparency, type ThemeMode } from "@/lib";
 
 type TitleBarProps = {
   fileName?: string;
@@ -37,6 +39,8 @@ const THEME_CHOICES: ThemeChoice[] = [
   { value: "frappe", label: "frappé", icon: Coffee },
   { value: "macchiato", label: "macchiato", icon: Coffee },
   { value: "mocha", label: "mocha", icon: Moon },
+  { value: "kanagawa", label: "kanagawa", icon: Waves },
+  { value: "rose-pine", label: "rose pine", icon: Flower2 },
 ];
 
 export function TitleBar({
@@ -63,7 +67,11 @@ export function TitleBar({
           ? Leaf
           : resolved === "mocha"
             ? Moon
-            : Coffee;
+            : resolved === "kanagawa"
+              ? Waves
+              : resolved === "rose-pine"
+                ? Flower2
+                : Coffee;
 
   return (
     <header className="mdv-titlebar" data-tauri-drag-region onMouseDown={startWindowDrag}>
@@ -87,7 +95,7 @@ export function TitleBar({
           <button
             type="button"
             className={`mdv-copybtn${copyPulse ? " is-copied" : ""}`}
-            data-tooltip={copyPulse ? "copied!" : "copy markdown (⌘⇧C)"}
+            data-tooltip={copyPulse ? "copied!" : shortcutLabel("copy markdown (⌘⇧C)")}
             aria-label={copyPulse ? "copied" : "copy markdown"}
             onClick={onCopyMarkdown}
           >
@@ -101,7 +109,7 @@ export function TitleBar({
         ) : null}
         {readingMode && onExportPdf ? (
           <Button
-            data-tooltip="export to pdf (⌘P)"
+            data-tooltip={shortcutLabel("export to pdf (⌘P)")}
             aria-label="export to pdf"
             onClick={onExportPdf}
             icon={<Icon icon={FileDown} size={13} strokeWidth={1.5} />}
@@ -109,7 +117,7 @@ export function TitleBar({
         ) : null}
         {onToggleReading ? (
           <Button
-            data-tooltip={readingMode ? "exit reading (esc)" : "reading mode (⌘.)"}
+            data-tooltip={readingMode ? "exit reading (esc)" : shortcutLabel("reading mode (⌘.)")}
             aria-label={readingMode ? "exit reading mode" : "reading mode"}
             aria-pressed={readingMode}
             onClick={onToggleReading}

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -39,14 +39,6 @@ async function renderMermaidBlocks(root: HTMLElement, theme: "default" | "dark")
     mermaidInitializedTheme = theme;
   }
 
-  // Mermaid leaves temporary <svg id="${id}-svg"> + measurement <div id="d${id}-svg">
-  // nodes in document.body after each render(). When the host pre is unmounted
-  // (save/reading-mode/source-change), those orphans linger and can collide with
-  // the next render. Purge them before re-rendering.
-  document.body
-    .querySelectorAll('svg[id^="mdv-mermaid-"], div[id^="dmdv-mermaid-"]')
-    .forEach((n) => n.remove());
-
   for (const pre of blocks) {
     const code = pre.querySelector("code")?.textContent ?? "";
     const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -42,12 +42,14 @@ async function renderMermaidBlocks(root: HTMLElement, theme: "default" | "dark")
   for (const pre of blocks) {
     const code = pre.querySelector("code")?.textContent ?? "";
     const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    console.debug("[marka.md/mermaid] rendering", { id, theme, codeLen: code.length, codePreview: code.slice(0, 60) });
     try {
       const { svg } = await mermaid.render(`${id}-svg`, code);
       pre.innerHTML = svg;
       pre.classList.add("is-rendered");
+      console.debug("[marka.md/mermaid] ✓ rendered", id);
     } catch (err) {
-      console.error("marka.md: mermaid render failed", err);
+      console.error("[marka.md/mermaid] ✗ render failed", { id, err, code: code.slice(0, 200) });
       // safe fallback — build with textContent, never innerHTML on user input
       pre.replaceChildren();
       const codeEl = document.createElement("code");

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -42,14 +42,12 @@ async function renderMermaidBlocks(root: HTMLElement, theme: "default" | "dark")
   for (const pre of blocks) {
     const code = pre.querySelector("code")?.textContent ?? "";
     const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    console.debug("[marka.md/mermaid] rendering", { id, theme, codeLen: code.length, codePreview: code.slice(0, 60) });
     try {
       const { svg } = await mermaid.render(`${id}-svg`, code);
       pre.innerHTML = svg;
       pre.classList.add("is-rendered");
-      console.debug("[marka.md/mermaid] ✓ rendered", id);
     } catch (err) {
-      console.error("[marka.md/mermaid] ✗ render failed", { id, err, code: code.slice(0, 200) });
+      console.error("marka.md: mermaid render failed", err);
       // safe fallback — build with textContent, never innerHTML on user input
       pre.replaceChildren();
       const codeEl = document.createElement("code");

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -39,6 +39,14 @@ async function renderMermaidBlocks(root: HTMLElement, theme: "default" | "dark")
     mermaidInitializedTheme = theme;
   }
 
+  // Mermaid leaves temporary <svg id="${id}-svg"> + measurement <div id="d${id}-svg">
+  // nodes in document.body after each render(). When the host pre is unmounted
+  // (save/reading-mode/source-change), those orphans linger and can collide with
+  // the next render. Purge them before re-rendering.
+  document.body
+    .querySelectorAll('svg[id^="mdv-mermaid-"], div[id^="dmdv-mermaid-"]')
+    .forEach((n) => n.remove());
+
   for (const pre of blocks) {
     const code = pre.querySelector("code")?.textContent ?? "";
     const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -137,6 +137,16 @@ export function Preview({ source }: PreviewProps) {
 
   const html = useMemo(() => renderMarkdown(source, theme), [source, theme, ready]);
 
+  // Imperatively set innerHTML — React's dangerouslySetInnerHTML re-applies the
+  // string on each parent re-render even when the value is unchanged, which
+  // wipes mermaid's post-render DOM mutations (and shiki's decorate-codeblock
+  // wrappers). Setting innerHTML in a useEffect that only fires when `html`
+  // actually changes preserves mermaid SVGs across save / saveStatus updates.
+  useEffect(() => {
+    if (!articleRef.current) return;
+    articleRef.current.innerHTML = html;
+  }, [html]);
+
   useEffect(() => {
     if (!articleRef.current) return;
     return decorateCodeBlocks(articleRef.current);
@@ -174,7 +184,6 @@ export function Preview({ source }: PreviewProps) {
         ref={articleRef}
         className="mdv-prose"
         data-theme={theme}
-        dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>
   );

--- a/src/components/files/context-menu.tsx
+++ b/src/components/files/context-menu.tsx
@@ -9,6 +9,8 @@ export type ContextMenuItem =
       onSelect: () => void;
       disabled?: boolean;
       hint?: string;
+      /** style as destructive (red on hover) — for delete + similar */
+      destructive?: boolean;
     }
   | "divider";
 
@@ -76,7 +78,7 @@ export function ContextMenu({ open, x, y, items, onClose }: ContextMenuProps) {
             key={`${item.label}-${i}`}
             type="button"
             role="menuitem"
-            className="mdv-menu__item"
+            className={`mdv-menu__item${item.destructive ? " mdv-menu__item--destructive" : ""}`}
             disabled={item.disabled}
             onClick={() => {
               if (item.disabled) return;

--- a/src/components/files/sidebar.tsx
+++ b/src/components/files/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FolderOpen, Search, X } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
-import { basename, dirname, startWindowDrag, walkMarkdownFiles, type FileEntry, type FlatFileEntry } from "@/lib";
+import { basename, dirname, shortcutLabel, startWindowDrag, walkMarkdownFiles, type FileEntry, type FlatFileEntry } from "@/lib";
 import emptyTowerUrl from "@/assets/mascot/empty-m.png";
 import { FileTree, type NewEntry } from "./file-tree";
 
@@ -144,7 +144,7 @@ export function Sidebar({
               />
             ) : null}
             <Button
-              data-tooltip="open folder (⌘⇧O)"
+              data-tooltip={shortcutLabel("open folder (⌘⇧O)")}
               aria-label="open folder"
               onClick={onOpenFolder}
               icon={<Icon icon={FolderOpen} size={13} strokeWidth={1.5} />}

--- a/src/components/overlays/command-palette.tsx
+++ b/src/components/overlays/command-palette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon, Kbd, Overlay } from "@/components/primitives";
+import { shortcutLabel } from "@/lib";
 import { CATEGORY_LABELS, CATEGORY_ORDER, type Command, type CommandCategory } from "@/lib/commands";
 
 export type { Command };
@@ -159,7 +160,7 @@ export function CommandPalette({ open, onClose, commands }: CommandPaletteProps)
                   {cmd.label}
                   {cmd.hint ? <span className="mdv-palette__hint"> · {cmd.hint}</span> : null}
                 </span>
-                {cmd.shortcut ? <Kbd className="mdv-kbd--muted">{cmd.shortcut}</Kbd> : null}
+                {cmd.shortcut ? <Kbd className="mdv-kbd--muted">{shortcutLabel(cmd.shortcut)}</Kbd> : null}
               </li>
             );
           })

--- a/src/components/overlays/help-overlay.tsx
+++ b/src/components/overlays/help-overlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Sparkles, X } from "lucide-react";
-import { Button, Icon, Kbd, Overlay } from "@/components/primitives";
+import { Button, Icon, Kbd, Overlay, Shortcut } from "@/components/primitives";
+import { shortcutLabel } from "@/lib";
 import writeUrl from "@/assets/mascot/write.png";
 
 type HelpOverlayProps = {
@@ -9,7 +10,7 @@ type HelpOverlayProps = {
   onReplayTutorial?: () => void;
 };
 
-type Row = { keys: string[]; label: string };
+type Row = { keys: string; label: string };
 
 type Group = { title: string; rows: Row[] };
 
@@ -17,41 +18,41 @@ const GROUPS: Group[] = [
   {
     title: "file",
     rows: [
-      { keys: ["⌘", "⇧", "O"], label: "open a folder of notes" },
-      { keys: ["⌘", "O"], label: "open a single .md file" },
-      { keys: ["⌘", "N"], label: "new untitled buffer" },
-      { keys: ["⌘", "S"], label: "save current file" },
-      { keys: ["⌘", "⌥", "Z"], label: "undo last sidebar file action" },
+      { keys: "⌘+⇧+O", label: "open a folder of notes" },
+      { keys: "⌘+O", label: "open a single .md file" },
+      { keys: "⌘+N", label: "new untitled buffer" },
+      { keys: "⌘+S", label: "save current file" },
+      { keys: "⌘+⌥+Z", label: "undo last sidebar file action" },
     ],
   },
   {
     title: "view",
     rows: [
-      { keys: ["⌘", "K"], label: "open command palette" },
-      { keys: ["⌘", "B"], label: "show / hide sidebar" },
-      { keys: ["⌘", "."], label: "toggle reading mode" },
-      { keys: ["⌃", "⌘", "F"], label: "toggle fullscreen" },
+      { keys: "⌘+K", label: "open command palette" },
+      { keys: "⌘+B", label: "show / hide sidebar" },
+      { keys: "⌘+.", label: "toggle reading mode" },
+      { keys: "⌃+⌘+F", label: "toggle fullscreen" },
     ],
   },
   {
     title: "edit",
     rows: [
-      { keys: ["⌘", "F"], label: "find / replace in editor" },
-      { keys: ["⌘", "G"], label: "find next match" },
+      { keys: "⌘+F", label: "find / replace in editor" },
+      { keys: "⌘+G", label: "find next match" },
     ],
   },
   {
     title: "share",
     rows: [
-      { keys: ["⌘", "⇧", "C"], label: "copy markdown to clipboard" },
-      { keys: ["⌘", "P"], label: "export to pdf" },
+      { keys: "⌘+⇧+C", label: "copy markdown to clipboard" },
+      { keys: "⌘+P", label: "export to pdf" },
     ],
   },
   {
     title: "help",
     rows: [
-      { keys: ["⌘", "/"], label: "open this help" },
-      { keys: ["esc"], label: "close any popup / overlay" },
+      { keys: "⌘+/", label: "open this help" },
+      { keys: "esc", label: "close any popup / overlay" },
     ],
   },
 ];
@@ -116,9 +117,11 @@ export function HelpOverlay({ open, onClose, onReplayTutorial }: HelpOverlayProp
                   {g.rows.map((s) => (
                     <li key={s.label} className="mdv-help__row">
                       <span className="mdv-help__keys">
-                        {s.keys.map((k, i) => (
-                          <Kbd key={`${s.label}-${i}`}>{k}</Kbd>
-                        ))}
+                        {s.keys.includes("+") ? (
+                          <Shortcut keys={s.keys} />
+                        ) : (
+                          <Kbd>{s.keys}</Kbd>
+                        )}
                       </span>
                       <span className="mdv-help__label">{s.label}</span>
                     </li>
@@ -133,7 +136,7 @@ export function HelpOverlay({ open, onClose, onReplayTutorial }: HelpOverlayProp
           <h3 className="mdv-help__h">tips</h3>
           <ul className="mdv-help__tips">
             {TIPS.map((tip) => (
-              <li key={tip}>{tip}</li>
+              <li key={tip}>{shortcutLabel(tip)}</li>
             ))}
           </ul>
         </section>

--- a/src/components/overlays/welcome-overlay.tsx
+++ b/src/components/overlays/welcome-overlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { ChevronLeft, ChevronRight, FolderOpen, Sparkles } from "lucide-react";
-import { Button, Icon, Kbd, Overlay } from "@/components/primitives";
+import { Button, Icon, Kbd, Overlay, Shortcut } from "@/components/primitives";
 import logoUrl from "@/assets/mascot/mdview-transpa-bg.png";
 import notebookUrl from "@/assets/mascot/notebook.png";
 import penUrl from "@/assets/mascot/pen.png";
@@ -35,7 +35,7 @@ const SLIDES: Slide[] = [
     title: "your context library",
     body: (
       <>
-        press <Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>O</Kbd> to load a folder of <code>.md</code> notes. the sidebar becomes your library — tap the 🔍 to search across every file in the tree.
+        press <Shortcut keys="⌘+⇧+O" /> to load a folder of <code>.md</code> notes. the sidebar becomes your library — tap the 🔍 to search across every file in the tree.
       </>
     ),
   },
@@ -44,7 +44,7 @@ const SLIDES: Slide[] = [
     title: "write side by side",
     body: (
       <>
-        type on the left, watch it render on the right. code blocks + mermaid diagrams — all live. <Kbd>⌘</Kbd><Kbd>S</Kbd> to save when ready.
+        type on the left, watch it render on the right. code blocks + mermaid diagrams — all live. <Shortcut keys="⌘+S" /> to save when ready.
       </>
     ),
   },
@@ -53,7 +53,7 @@ const SLIDES: Slide[] = [
     title: "read, then share",
     body: (
       <>
-        <Kbd>⌘</Kbd><Kbd>.</Kbd> flips to calm reading mode for proofing. when it looks right, <Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>C</Kbd> copies the markdown — paste into any ai chat or agent.
+        <Shortcut keys="⌘+." /> flips to calm reading mode for proofing. when it looks right, <Shortcut keys="⌘+⇧+C" /> copies the markdown — paste into any ai chat or agent.
       </>
     ),
   },
@@ -62,7 +62,7 @@ const SLIDES: Slide[] = [
     title: "you're set",
     body: (
       <>
-        <Kbd>⌘</Kbd><Kbd>K</Kbd> for all commands. <Kbd>⌘</Kbd><Kbd>/</Kbd> for help. happy writing.
+        <Shortcut keys="⌘+K" /> for all commands. <Shortcut keys="⌘+/" /> for help. happy writing.
       </>
     ),
   },
@@ -178,7 +178,7 @@ export function WelcomeOverlay({ open, onClose, onOpenFolder }: WelcomeOverlayPr
         <div className="mdv-welcome__hint">
           {isLast ? (
             <>
-              <Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>O</Kbd> <span>open a folder</span>
+              <Shortcut keys="⌘+⇧+O" /> <span>open a folder</span>
               <span className="mdv-welcome__hint-sep">·</span>
               <Kbd>↵</Kbd> <span>or click</span>
               <span className="mdv-welcome__hint-sep">·</span>

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -3,4 +3,5 @@ export { Icon } from "./icon";
 export { Popover } from "./popover";
 export { Overlay } from "./overlay";
 export { Kbd } from "./kbd";
+export { Shortcut } from "./shortcut";
 export { TooltipRoot } from "./tooltip-root";

--- a/src/components/primitives/shortcut.tsx
+++ b/src/components/primitives/shortcut.tsx
@@ -1,0 +1,33 @@
+import { Fragment } from "react";
+import { displayKey } from "@/lib";
+import { Kbd } from "./kbd";
+
+type ShortcutProps = {
+  /**
+   * Mac-glyph format separated by `+`. Examples:
+   *   "⌘+S"        → mac: ⌘ S        | win: Ctrl S
+   *   "⌘+⇧+O"      → mac: ⌘ ⇧ O      | win: Ctrl Shift O
+   *   "⌘+⌥+Z"      → mac: ⌘ ⌥ Z      | win: Ctrl Alt Z
+   */
+  keys: string;
+  /** rendered between key chips. Defaults to nothing (chips sit flush, css gap). */
+  separator?: string;
+};
+
+/**
+ * Platform-aware shortcut display. Converts mac glyphs to Ctrl/Alt/Shift
+ * when running on Windows/Linux. Render-only — does NOT bind anything.
+ */
+export function Shortcut({ keys, separator }: ShortcutProps) {
+  const segments = keys.split("+").map((s) => s.trim()).filter(Boolean);
+  return (
+    <>
+      {segments.map((seg, i) => (
+        <Fragment key={`${seg}-${i}`}>
+          {i > 0 && separator ? <span aria-hidden>{separator}</span> : null}
+          <Kbd>{displayKey(seg)}</Kbd>
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -208,11 +208,11 @@ export function buildCommands(actions: CommandActions): Command[] {
     ),
     {
       id: "transparency-on",
-      label: "transparency: on",
-      hint: "macOS vibrancy through the window",
+      label: "transparency: on (74%)",
+      hint: "macOS vibrancy through the window — adjust opacity in theme menu",
       icon: Sparkles,
       category: "theme",
-      action: () => setTransparency(true),
+      action: () => setTransparency(74),
     },
     {
       id: "transparency-off",
@@ -220,7 +220,7 @@ export function buildCommands(actions: CommandActions): Command[] {
       hint: "solid window background",
       icon: Sparkles,
       category: "theme",
-      action: () => setTransparency(false),
+      action: () => setTransparency(100),
     },
     {
       id: "help",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,6 +13,7 @@ export { STORAGE_KEYS, type StorageKey } from "./storage";
 export { buildCommands, type Command, type CommandActions } from "./commands";
 export { estimateTokens, formatTokens } from "./bundle";
 export { startWindowDrag } from "./window-drag";
+export { IS_MAC, IS_WINDOWS, IS_LINUX, displayKey, shortcutLabel } from "./platform";
 export {
   pickFolder,
   pickMarkdownFile,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export {
   setThemeMode,
   setTransparency,
   getSystemTheme,
+  previewTheme,
   type Theme,
   type ThemeMode,
 } from "./theme";

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -12,6 +12,8 @@ const THEMES = {
   macchiato: "catppuccin-macchiato",
   mocha: "catppuccin-mocha",
   matcha: "vitesse-light",
+  kanagawa: "kanagawa-wave",
+  "rose-pine": "rose-pine",
 } as const;
 
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -20,7 +22,15 @@ let highlighter: Highlighter | null = null;
 function getHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: [THEMES.latte, THEMES.frappe, THEMES.macchiato, THEMES.mocha, THEMES.matcha],
+      themes: [
+        THEMES.latte,
+        THEMES.frappe,
+        THEMES.macchiato,
+        THEMES.mocha,
+        THEMES.matcha,
+        THEMES.kanagawa,
+        THEMES["rose-pine"],
+      ],
       langs: LANGS,
     })
       .then((h) => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -14,6 +14,7 @@ const THEMES = {
   matcha: "vitesse-light",
   kanagawa: "kanagawa-wave",
   "rose-pine": "rose-pine",
+  ayu: "ayu-dark",
 } as const;
 
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -22,15 +23,7 @@ let highlighter: Highlighter | null = null;
 function getHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: [
-        THEMES.latte,
-        THEMES.frappe,
-        THEMES.macchiato,
-        THEMES.mocha,
-        THEMES.matcha,
-        THEMES.kanagawa,
-        THEMES["rose-pine"],
-      ],
+      themes: Object.values(THEMES),
       langs: LANGS,
     })
       .then((h) => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -64,13 +64,10 @@ const md = new MarkdownIt({
     try {
       return highlighter.codeToHtml(code, {
         lang: language,
-        themes: {
-          latte: THEMES.latte,
-          frappe: THEMES.frappe,
-          macchiato: THEMES.macchiato,
-          mocha: THEMES.mocha,
-          matcha: THEMES.matcha,
-        },
+        // pass full THEMES map so EVERY registered theme gets a css-var variant
+        // (kanagawa / rose-pine / ayu were missing before, so code blocks fell
+        // back to no-color when active theme didn't have a variant).
+        themes: THEMES,
         defaultColor: false,
       });
     } catch {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,7 +3,13 @@ import taskLists from "markdown-it-task-lists";
 import { createHighlighter, type Highlighter } from "shiki";
 import type { Theme } from "./theme";
 
-let mermaidCounter = 0;
+// random suffix per mermaid block — avoids id collisions when html re-renders
+// (which happens on save, reading-mode toggle, theme switch). Mermaid creates
+// a temporary <svg id="${id}-svg"> in document.body and tearing down the old
+// pre while the new render uses the same id was causing silent failures.
+function mermaidId(): string {
+  return `mdv-mermaid-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 const LANGS = ["markdown", "ts", "tsx", "js", "jsx", "json", "rust", "bash", "css", "html", "python", "go"];
 const THEMES = {
@@ -51,7 +57,7 @@ const md = new MarkdownIt({
   highlight: (code, lang) => {
     // mermaid blocks bypass shiki — Preview component renders them as svg
     if (lang === "mermaid") {
-      const id = `mdv-mermaid-${++mermaidCounter}`;
+      const id = mermaidId();
       const encoded = code
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,46 @@
+// Platform detection. Computed once at module load — userAgent doesn't change.
+const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+
+export const IS_MAC = /Mac|iPhone|iPad|iPod/i.test(ua);
+export const IS_WINDOWS = /Windows/i.test(ua);
+export const IS_LINUX = /Linux/i.test(ua) && !/Android/i.test(ua);
+
+// Translate a mac-style shortcut key glyph to the current platform's label.
+// macOS: ⌘ ⌥ ⇧ ⌃ stay as glyphs.
+// Windows / Linux: ⌘ → Ctrl, ⌥ → Alt, ⇧ → Shift, ⌃ → Ctrl (rare).
+export function displayKey(macGlyph: string): string {
+  if (IS_MAC) return macGlyph;
+  switch (macGlyph) {
+    case "⌘":
+      return "Ctrl";
+    case "⌥":
+      return "Alt";
+    case "⇧":
+      return "Shift";
+    case "⌃":
+      return "Ctrl";
+    default:
+      return macGlyph;
+  }
+}
+
+// Translate a whole mac-style label (used in tooltip attribute strings) to the
+// current platform's idiomatic form. Examples:
+//   "reading mode (⌘.)"           mac → "reading mode (⌘.)"
+//                                 win → "reading mode (Ctrl+.)"
+//   "copy markdown (⌘⇧C)"         mac → "copy markdown (⌘⇧C)"
+//                                 win → "copy markdown (Ctrl+Shift+C)"
+//   "fullscreen (⌃⌘F)"           mac → "fullscreen (⌃⌘F)"
+//                                 win → "fullscreen (Ctrl+F)" (no extra Ctrl)
+// Use this for any string passed to `data-tooltip` or button `aria-label`.
+export function shortcutLabel(label: string): string {
+  if (IS_MAC) return label;
+  return label
+    .replace(/⌘\s*⇧\s*/g, "Ctrl+Shift+")
+    .replace(/⌘\s*⌥\s*/g, "Ctrl+Alt+")
+    .replace(/⌃\s*⌘\s*/g, "Ctrl+")
+    .replace(/⌘\s*/g, "Ctrl+")
+    .replace(/⌥\s*/g, "Alt+")
+    .replace(/⇧\s*/g, "Shift+")
+    .replace(/⌃\s*/g, "Ctrl+");
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -67,6 +67,21 @@ export function setThemeMode(mode: ThemeMode): void {
   modeListeners.forEach((fn) => fn());
 }
 
+/**
+ * Visual-only theme preview — does NOT touch localStorage or fire listeners.
+ * Used by the theme menu's hover behavior: hover previews, click commits via
+ * setThemeMode. Pass `null` to revert to the user's stored mode.
+ */
+export function previewTheme(theme: Theme | null): void {
+  if (typeof document === "undefined") return;
+  if (theme === null) {
+    // revert to whatever's persisted
+    apply(readMode());
+    return;
+  }
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
 function subscribeMode(fn: () => void): () => void {
   modeListeners.add(fn);
   return () => {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,15 @@
 import { useSyncExternalStore } from "react";
 import { STORAGE_KEYS } from "./storage";
 
-export type Theme = "latte" | "frappe" | "macchiato" | "mocha" | "matcha" | "kanagawa" | "rose-pine";
+export type Theme =
+  | "latte"
+  | "frappe"
+  | "macchiato"
+  | "mocha"
+  | "matcha"
+  | "kanagawa"
+  | "rose-pine"
+  | "ayu";
 export type ThemeMode = "system" | Theme;
 
 const VALID: ReadonlyArray<ThemeMode> = [
@@ -13,6 +21,7 @@ const VALID: ReadonlyArray<ThemeMode> = [
   "matcha",
   "kanagawa",
   "rose-pine",
+  "ayu",
 ];
 
 const STORAGE_KEY = STORAGE_KEYS.themeMode;
@@ -73,29 +82,46 @@ function subscribeTransparency(fn: () => void): () => void {
 }
 
 const TRANSPARENCY_KEY = STORAGE_KEYS.transparency;
+const TRANSPARENCY_OFF = 100;
+const TRANSPARENCY_DEFAULT_ON = 74;
 
-function readTransparency(): boolean {
-  if (typeof window === "undefined") return false;
+// Opacity is a 0-100 integer. 100 = fully opaque (off). <100 = transparency on
+// at that opacity. Migrates legacy "on"/"off" string values from prior versions.
+function readTransparencyOpacity(): number {
+  if (typeof window === "undefined") return TRANSPARENCY_OFF;
   try {
-    return window.localStorage.getItem(TRANSPARENCY_KEY) === "on";
+    const v = window.localStorage.getItem(TRANSPARENCY_KEY);
+    if (v === null) return TRANSPARENCY_OFF;
+    if (v === "on") return TRANSPARENCY_DEFAULT_ON;
+    if (v === "off") return TRANSPARENCY_OFF;
+    const n = Number.parseInt(v, 10);
+    if (Number.isFinite(n) && n >= 0 && n <= 100) return n;
+    return TRANSPARENCY_OFF;
   } catch {
-    return false;
+    return TRANSPARENCY_OFF;
   }
 }
 
-function applyTransparency(on: boolean): void {
+function applyTransparencyOpacity(opacity: number): void {
   if (typeof document === "undefined") return;
-  if (on) document.documentElement.setAttribute("data-transparency", "on");
-  else document.documentElement.removeAttribute("data-transparency");
+  const clamped = Math.max(0, Math.min(100, Math.round(opacity)));
+  if (clamped >= TRANSPARENCY_OFF) {
+    document.documentElement.removeAttribute("data-transparency");
+    document.documentElement.style.removeProperty("--user-opacity");
+  } else {
+    document.documentElement.setAttribute("data-transparency", "on");
+    document.documentElement.style.setProperty("--user-opacity", String(clamped / 100));
+  }
 }
 
-export function setTransparency(on: boolean): void {
+export function setTransparency(opacity: number): void {
+  const clamped = Math.max(0, Math.min(100, Math.round(opacity)));
   try {
-    window.localStorage.setItem(TRANSPARENCY_KEY, on ? "on" : "off");
+    window.localStorage.setItem(TRANSPARENCY_KEY, String(clamped));
   } catch {
     // ignore
   }
-  applyTransparency(on);
+  applyTransparencyOpacity(clamped);
   transparencyListeners.forEach((fn) => fn());
 }
 
@@ -107,7 +133,7 @@ declare global {
 if (typeof window !== "undefined" && !globalThis.__markaThemeInit) {
   globalThis.__markaThemeInit = true;
   apply(readMode());
-  applyTransparency(readTransparency());
+  applyTransparencyOpacity(readTransparencyOpacity());
   const mq = window.matchMedia(MQ);
   mq.addEventListener("change", () => {
     if (readMode() === "system") {
@@ -130,9 +156,19 @@ export function useThemeMode(): { mode: ThemeMode; resolved: Theme; setMode: (m:
   return { mode, resolved: resolve(mode), setMode: setThemeMode };
 }
 
-export function useTransparency(): { on: boolean; set: (v: boolean) => void } {
-  const on = useSyncExternalStore(subscribeTransparency, readTransparency, () => false);
-  return { on, set: setTransparency };
+export function useTransparency(): {
+  /** opacity 0-100. 100 = fully opaque (off). <100 = transparency on. */
+  opacity: number;
+  /** convenience boolean: true when transparency is active (opacity < 100). */
+  on: boolean;
+  set: (opacity: number) => void;
+} {
+  const opacity = useSyncExternalStore(
+    subscribeTransparency,
+    readTransparencyOpacity,
+    () => TRANSPARENCY_OFF,
+  );
+  return { opacity, on: opacity < TRANSPARENCY_OFF, set: setTransparency };
 }
 
 export function useTheme(): Theme {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from "react";
 import { STORAGE_KEYS } from "./storage";
 
-export type Theme = "latte" | "frappe" | "macchiato" | "mocha" | "matcha";
+export type Theme = "latte" | "frappe" | "macchiato" | "mocha" | "matcha" | "kanagawa" | "rose-pine";
 export type ThemeMode = "system" | Theme;
 
 const VALID: ReadonlyArray<ThemeMode> = [
@@ -11,6 +11,8 @@ const VALID: ReadonlyArray<ThemeMode> = [
   "macchiato",
   "mocha",
   "matcha",
+  "kanagawa",
+  "rose-pine",
 ];
 
 const STORAGE_KEY = STORAGE_KEYS.themeMode;

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -189,6 +189,30 @@
   text-decoration: var(--shiki-matcha-text-decoration, inherit) !important;
 }
 
+.mdv-prose[data-theme="kanagawa"] .shiki,
+.mdv-prose[data-theme="kanagawa"] .shiki span {
+  color: var(--shiki-kanagawa) !important;
+  font-style: var(--shiki-kanagawa-font-style, inherit) !important;
+  font-weight: var(--shiki-kanagawa-font-weight, inherit) !important;
+  text-decoration: var(--shiki-kanagawa-text-decoration, inherit) !important;
+}
+
+.mdv-prose[data-theme="rose-pine"] .shiki,
+.mdv-prose[data-theme="rose-pine"] .shiki span {
+  color: var(--shiki-rose-pine) !important;
+  font-style: var(--shiki-rose-pine-font-style, inherit) !important;
+  font-weight: var(--shiki-rose-pine-font-weight, inherit) !important;
+  text-decoration: var(--shiki-rose-pine-text-decoration, inherit) !important;
+}
+
+.mdv-prose[data-theme="ayu"] .shiki,
+.mdv-prose[data-theme="ayu"] .shiki span {
+  color: var(--shiki-ayu) !important;
+  font-style: var(--shiki-ayu-font-style, inherit) !important;
+  font-weight: var(--shiki-ayu-font-weight, inherit) !important;
+  text-decoration: var(--shiki-ayu-text-decoration, inherit) !important;
+}
+
 /* mermaid diagram container */
 .mdv-mermaid {
   display: flex;

--- a/src/styles/files/sidebar.css
+++ b/src/styles/files/sidebar.css
@@ -374,7 +374,7 @@
 
 .mdv-context-menu .mdv-menu__item {
   width: 100%;
-  padding: 5px 9px;
+  padding: 4px 9px;
   background: transparent;
   border: 0;
   cursor: pointer;
@@ -393,7 +393,13 @@
 }
 
 .mdv-context-menu .mdv-menu__divider {
-  margin: 3px 4px;
+  margin: 2px 6px;
+}
+
+/* destructive action (delete) — accent red only on hover so it doesn't shout */
+.mdv-context-menu .mdv-menu__item--destructive:hover {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
 }
 
 .mdv-context-menu .mdv-menu__item-hint {

--- a/src/styles/shared/menu.css
+++ b/src/styles/shared/menu.css
@@ -160,3 +160,115 @@
   background: #fff;
   border-color: transparent;
 }
+
+/* opacity slider (transparency control in theme menu) */
+.mdv-menu__slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 4px 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--fg);
+  border-radius: var(--radius-sm);
+}
+
+.mdv-menu__slider.is-active .mdv-menu__slider-icon,
+.mdv-menu__slider.is-active .mdv-menu__slider-value {
+  color: var(--accent);
+}
+
+.mdv-menu__slider-icon {
+  grid-row: 1;
+  grid-column: 1;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+  transition: color var(--dur-fast) var(--easing);
+}
+
+.mdv-menu__slider-label {
+  grid-row: 1;
+  grid-column: 2;
+  font-size: 12px;
+  letter-spacing: 0.005em;
+}
+
+.mdv-menu__slider-value {
+  grid-row: 1;
+  grid-column: 3;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  min-width: 32px;
+  text-align: right;
+  transition: color var(--dur-fast) var(--easing);
+}
+
+.mdv-menu__slider-input {
+  grid-row: 2;
+  grid-column: 1 / -1;
+  width: 100%;
+  height: 16px;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  margin-top: 2px;
+}
+
+.mdv-menu__slider-input::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.mdv-menu__slider-input::-moz-range-track {
+  height: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.mdv-menu__slider-input::-moz-range-progress {
+  height: 3px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.mdv-menu__slider-input::-webkit-slider-thumb {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--accent);
+  border: 2px solid var(--surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  margin-top: -4.5px;
+  transition: transform var(--dur-fast) var(--easing);
+}
+
+.mdv-menu__slider-input::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--accent);
+  border: 2px solid var(--surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  transition: transform var(--dur-fast) var(--easing);
+}
+
+.mdv-menu__slider-input:hover::-webkit-slider-thumb,
+.mdv-menu__slider-input:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.15);
+}
+
+.mdv-menu__slider-input:hover::-moz-range-thumb,
+.mdv-menu__slider-input:focus-visible::-moz-range-thumb {
+  transform: scale(1.15);
+}
+
+.mdv-menu__slider-input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 50%, transparent);
+  outline-offset: 4px;
+  border-radius: 8px;
+}

--- a/src/styles/shared/transparency.css
+++ b/src/styles/shared/transparency.css
@@ -1,0 +1,29 @@
+/* Ghostty-style window transparency.
+   When user opts in (slider < 100), ALL chrome surfaces become transparent so
+   the single rgba background on .mdv-app + the native macOS NSVisualEffect
+   vibrancy show through uniformly. Without this, each chrome row stacks its
+   own rgba layer on top of the shell, producing the "only 2 panes look
+   transparent" effect.
+
+   .mdv-app keeps its var(--bg) (which becomes rgba when transparency is on).
+   Surface popovers (menu, popover, palette) intentionally keep --surface so
+   they remain readable on top of the translucent background. */
+
+:root[data-transparency="on"] .mdv-titlebar,
+:root[data-transparency="on"] .mdv-breadcrumb,
+:root[data-transparency="on"] .mdv-statusbar,
+:root[data-transparency="on"] .mdv-sidebar,
+:root[data-transparency="on"] .mdv-sidebar__inner,
+:root[data-transparency="on"] .mdv-editor,
+:root[data-transparency="on"] .mdv-editor .cm-editor,
+:root[data-transparency="on"] .mdv-editor .cm-gutters,
+:root[data-transparency="on"] .mdv-editor .cm-scroller,
+:root[data-transparency="on"] .mdv-preview,
+:root[data-transparency="on"] .mdv-prose {
+  background: transparent !important;
+}
+
+/* preserve hover feedback on translucent surfaces — rgba lets the blur show through */
+:root[data-transparency="on"] .mdv-sidebar__row:hover {
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -30,16 +30,16 @@
   color-scheme: light;
 }
 
-/* catppuccin frappé */
+/* catppuccin frappé — soft cool dark, mauve signature (distinct from macchiato's peach) */
 :root[data-theme="frappe"] {
-  --bg: #303446;
+  --bg: #303446;            /* base */
   --bg-rgb: 48, 52, 70;
-  --fg: #c6d0f5;
-  --muted: #838ba7;
-  --border: #414559;
-  --accent: #ef9f76;
-  --surface: #292c3c;
-  --surface-hover: #414559;
+  --fg: #c6d0f5;            /* text */
+  --muted: #737994;         /* overlay0 — official spec (was incorrectly overlay1) */
+  --border: #414559;        /* surface0 */
+  --accent: #ca9ee6;        /* mauve — distinct cool-purple */
+  --surface: #292c3c;       /* mantle */
+  --surface-hover: #51576d; /* surface1 */
   --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.2);
   color-scheme: dark;
 }
@@ -101,6 +101,20 @@
   color-scheme: dark;
 }
 
+/* ayu mirage — warm dark, orange-red signature */
+:root[data-theme="ayu"] {
+  --bg: #1f2430;            /* common.bg */
+  --bg-rgb: 31, 36, 48;
+  --fg: #cbccc6;            /* common.fg */
+  --muted: #707a8c;         /* ui.fg — readable on dark bg */
+  --border: #33415e;        /* ui.line */
+  --accent: #ffa759;        /* common.accent — warm orange */
+  --surface: #191e2a;       /* editor.gutter */
+  --surface-hover: #2d3343; /* ui.selection.bg */
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+  color-scheme: dark;
+}
+
 /* rose pine — soho-vibes dark (base + rose) */
 :root[data-theme="rose-pine"] {
   --bg: #191724;            /* base */
@@ -142,13 +156,8 @@
   }
 }
 
-/* OPT-IN transparency: applied only when user enables it */
+/* OPT-IN transparency. --user-opacity is set by theme.ts when slider < 100.
+   Default 0.74 if attribute is on but JS didn't set a value (rare race). */
 :root[data-transparency="on"] {
-  --bg: rgba(var(--bg-rgb), 0.74);
-}
-/* light themes need higher opacity for readability over bright wallpapers */
-:root[data-transparency="on"][data-theme="latte"],
-:root[data-transparency="on"][data-theme="light"],
-:root[data-transparency="on"][data-theme="matcha"] {
-  --bg: rgba(var(--bg-rgb), 0.92);
+  --bg: rgba(var(--bg-rgb), var(--user-opacity, 0.74));
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -87,6 +87,34 @@
   color-scheme: dark;
 }
 
+/* kanagawa — ink-wash dark (sumiInk + crystalBlue) */
+:root[data-theme="kanagawa"] {
+  --bg: #1f1f28;            /* sumiInk1 — wave base */
+  --bg-rgb: 31, 31, 40;
+  --fg: #dcd7ba;            /* fujiWhite — warm cream */
+  --muted: #727169;         /* fujiGray */
+  --border: #363646;        /* sumiInk3 — subtle divider */
+  --accent: #7e9cd8;        /* crystalBlue — iconic */
+  --surface: #2a2a37;       /* sumiInk2 */
+  --surface-hover: #363646; /* sumiInk3 */
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+  color-scheme: dark;
+}
+
+/* rose pine — soho-vibes dark (base + rose) */
+:root[data-theme="rose-pine"] {
+  --bg: #191724;            /* base */
+  --bg-rgb: 25, 23, 36;
+  --fg: #e0def4;            /* text */
+  --muted: #6e6a86;         /* muted */
+  --border: #26233a;        /* overlay */
+  --accent: #ebbcba;        /* rose — signature pink */
+  --surface: #1f1d2e;       /* surface */
+  --surface-hover: #26233a; /* overlay */
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.28);
+  color-scheme: dark;
+}
+
 /* fallback when no data-theme yet (system check before JS) */
 :root:not([data-theme]) {
   --bg: #eff1f5;


### PR DESCRIPTION
## what

bundles the v1.3.3 quality-of-life release.

## changes

### features
- **platform-aware shortcut display** — auto-swaps ⌘/⌥/⇧ → Ctrl/Alt/Shift on Windows/Linux across all overlays, tooltips, palette items
- **3 new themes** — kanagawa 🌊 (ink-wash dark + crystal blue), rose-pine 🌸 (warm dark + rose accent), ayu 🌅 (warm orange-red)
- **transparency slider** (continuous opacity 0-100, replaces on/off toggle)
- **ghostty-style window transparency** — applies whole-window via OS vibrancy, no more stacked-opacity chrome
- **hover-to-preview themes** in menu — preview on hover (60ms debounce), commit on click
- **delete file/folder** in sidebar context menu (red destructive style, native confirm)
- **GitHub Sponsors** — `.github/FUNDING.yml` added (auto-displays Sponsor button)
- **auto-generated changelog** in CI — release body now shows real commits per release, not boilerplate

### fixes
- **mermaid diagrams disappearing on save** — React was re-applying \`dangerouslySetInnerHTML\` on every parent re-render, wiping mermaid's post-render SVG mutations. Switched to imperative \`innerHTML\` in useEffect so React only manages the article shell.
- **frappé + macchiato visual collision** — frappé now uses official mauve accent (#ca9ee6) + Cloud icon, distinct from macchiato's peach Coffee
- **catppuccin frappé palette accuracy** — muted color was using Overlay1 instead of Overlay0 per official spec
- **shiki multi-theme map** — kanagawa/rose-pine/ayu were missing from \`codeToHtml\` themes, code blocks rendered uncolored in those themes
- **chained ternary ActiveIcon resolver** → derived from THEME_CHOICES (DRY)
- **context menu spacing** — tightened padding/divider margins

### chores
- past 21 release bodies backfilled with real commit lists (one-shot script)

## test plan (local)

- [x] dev server boots clean, type-check passes
- [x] all 8 themes render correctly on macOS (Apple Silicon)
- [x] code blocks highlight in every theme
- [x] mermaid diagrams render + persist through save + reading-mode toggle
- [x] window-drag still works on all 4 surfaces
- [x] context menu delete confirms + actually deletes
- [x] transparency slider drives opacity 0-100, persists across launches

## risks

- new themes use shiki built-ins (kanagawa-wave, rose-pine, ayu-dark) — verified bundled
- imperative innerHTML approach is unusual but well-justified (see commit message)
- past release backfill is a one-time fix; release.yml handles future ones automatically