### PR TITLE
fix(v1.3.4): expand shiki LANGS to 36 (resolves #18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.3"
+version = "1.3.4"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -11,7 +11,29 @@ function mermaidId(): string {
   return `mdv-mermaid-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-const LANGS = ["markdown", "ts", "tsx", "js", "jsx", "json", "rust", "bash", "css", "html", "python", "go"];
+// expanded language list — covers the long tail of code blocks users actually
+// paste from their AI context (resolves #18: c/java/cpp were missing).
+// Shiki lazy-loads grammars; listing more here just registers them eagerly.
+const LANGS = [
+  // existing
+  "markdown", "ts", "tsx", "js", "jsx", "json", "rust", "bash", "css", "html", "python", "go",
+  // systems / compiled
+  "c", "cpp", "csharp", "objective-c",
+  // jvm / .net
+  "java", "kotlin", "scala", "groovy",
+  // mobile / swift
+  "swift",
+  // scripting
+  "ruby", "php", "lua", "perl", "r", "elixir", "haskell",
+  // data / config
+  "sql", "yaml", "toml", "xml", "ini",
+  // shell / devops
+  "shellscript", "powershell", "dockerfile", "makefile", "nginx",
+  // diff / vcs
+  "diff", "git-commit",
+  // misc commonly-pasted
+  "graphql", "protobuf", "regex", "vim", "jsonc",
+];
 const THEMES = {
   latte: "catppuccin-latte",
   frappe: "catppuccin-frappe",


### PR DESCRIPTION
## what

Adds c, cpp, csharp, java, kotlin, swift, ruby, php, sql, yaml, toml, dockerfile, diff, graphql, and ~20 others to the eagerly-loaded shiki languages list.

## why

Reported in #18: code blocks tagged with \`c\` / \`java\` (and many others) rendered as plain text because they weren't in our \`LANGS\` array. The \`highlight\` callback in \`markdown.ts\` falls back to \`text\` when the language isn't loaded, hence no syntax colors.

## scope

In-app code blocks only. The PDF export path uses the same rendered HTML, so colors should carry into the print dialog as well — confirming with @arijit4 once it ships.

## resolves

- #18 (in-app highlighting). PDF export will be re-tested as part of the same flow.

## test plan

- [x] type-check passes
- [x] dev build renders \`\`\`java / \`\`\`c blocks with shiki colors
- [ ] tested in production binary once CI ships