### PR TITLE
fix(v1.3.5): save-as for untitled buffers + PDF syntax colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.4"
+version = "1.3.5"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -361,6 +361,8 @@ export function App() {
   // tiny "just copied!" pulse for the breadcrumb copy button + ambient toast
   const [copyPulse, setCopyPulse] = useState(false);
   const [copyToast, setCopyToast] = useState(false);
+  // toast shown after a successful save-as so the user knows where the file landed
+  const [saveAsToast, setSaveAsToast] = useState<string | null>(null);
   const copyMarkdown = useCallback(async () => {
     if (!source) return;
     try {
@@ -449,6 +451,9 @@ export function App() {
     setActivePath(target);
     // refresh sidebar in case the file landed inside the currently-open root
     bumpTree();
+    // toast so user knows where the file landed
+    setSaveAsToast(`saved to ${basename(target)}`);
+    window.setTimeout(() => setSaveAsToast(null), 2400);
   }, [activePath, rootPath, source, saveNow, setActivePath]);
 
   // refs to source + savedContent so handleExternalChange has stable identity.
@@ -1137,6 +1142,13 @@ export function App() {
         message="copied to clipboard · paste anywhere"
         variant="info"
         onDismiss={() => setCopyToast(false)}
+      />
+
+      <Toast
+        open={saveAsToast != null && loadError == null}
+        message={saveAsToast ?? ""}
+        variant="info"
+        onDismiss={() => setSaveAsToast(null)}
       />
 
       <Toast

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -40,6 +40,7 @@ import {
   moveEntry,
   pickFolder,
   pickMarkdownFile,
+  pickSaveMarkdown,
   readMarkdown,
   removeEntry,
   renameEntry,
@@ -237,6 +238,18 @@ export function App() {
       img { max-width: 100%; height: auto; border-radius: 6px; break-inside: avoid; }
       pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; }
       pre.shiki, pre.shiki * { font-family: inherit; }
+      /* PDF is a "document" — force catppuccin-latte palette regardless of
+         the user's active app theme. shiki emits --shiki-latte vars inline on
+         every span (multi-theme mode), so we just pick that variant for print.
+         Without this rule, spans would fall back to inherited body color
+         (looks like plain monospace text — no syntax colors). */
+      .shiki, .shiki span {
+        background-color: transparent !important;
+        color: var(--shiki-latte) !important;
+        font-style: var(--shiki-latte-font-style, inherit) !important;
+        font-weight: var(--shiki-latte-font-weight, inherit) !important;
+        text-decoration: var(--shiki-latte-text-decoration, inherit) !important;
+      }
       blockquote {
         border-left: 3px solid var(--paccent);
         padding-left: 16px;
@@ -418,6 +431,25 @@ export function App() {
     },
     [],
   );
+
+  // Save As — opens the native save dialog and writes the buffer to the
+  // chosen path. Used by:
+  //   - ⌘S when the current buffer is untitled (no activePath) — previously
+  //     this was a no-op on all platforms (the bug arijit4 reported in #17
+  //     and Matt confirmed on macOS)
+  //   - ⌘⇧S explicitly, to "save a copy" of an existing file to a new location
+  const saveAs = useCallback(async () => {
+    // suggest a default location: <rootPath>/untitled.md if a folder is open,
+    // else just "untitled.md" (dialog will land in the OS default folder)
+    const defaultPath = activePath
+      ?? (rootPath ? joinPath(rootPath, "untitled.md") : "untitled.md");
+    const target = await pickSaveMarkdown(defaultPath);
+    if (!target) return; // user cancelled — keep buffer dirty, no error
+    await saveNow(target, source);
+    setActivePath(target);
+    // refresh sidebar in case the file landed inside the currently-open root
+    bumpTree();
+  }, [activePath, rootPath, source, saveNow, setActivePath]);
 
   // refs to source + savedContent so handleExternalChange has stable identity.
   // without this, every keystroke recreates the callback → useFileWatcher's
@@ -873,9 +905,18 @@ export function App() {
       },
       "mod+s": (e: KeyboardEvent) => {
         e.preventDefault();
-        if (activePath && source !== savedContent) {
-          void saveNow(activePath, source);
+        if (activePath) {
+          // existing file — only write if dirty
+          if (source !== savedContent) void saveNow(activePath, source);
+        } else {
+          // untitled buffer — open native save dialog (resolves #17 save half + macOS parity)
+          void saveAs();
         }
+      },
+      "mod+shift+s": (e: KeyboardEvent) => {
+        e.preventDefault();
+        // explicit "save as" — works on both untitled and existing buffers
+        void saveAs();
       },
       "mod+n": (e: KeyboardEvent) => {
         e.preventDefault();
@@ -928,6 +969,7 @@ export function App() {
       source,
       savedContent,
       saveNow,
+      saveAs,
       handleOpenFile,
       handleOpenFolder,
       handleNewFile,

--- a/src/components/overlays/help-overlay.tsx
+++ b/src/components/overlays/help-overlay.tsx
@@ -22,6 +22,7 @@ const GROUPS: Group[] = [
       { keys: "⌘+O", label: "open a single .md file" },
       { keys: "⌘+N", label: "new untitled buffer" },
       { keys: "⌘+S", label: "save current file" },
+      { keys: "⌘+⇧+S", label: "save as / copy to new location" },
       { keys: "⌘+⌥+Z", label: "undo last sidebar file action" },
     ],
   },

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,4 +1,4 @@
-import { open } from "@tauri-apps/plugin-dialog";
+import { open, save } from "@tauri-apps/plugin-dialog";
 import { readDir, readFile, readTextFile, writeTextFile, exists, stat, rename, mkdir, remove } from "@tauri-apps/plugin-fs";
 
 export type FileEntry = {
@@ -25,6 +25,20 @@ export async function pickMarkdownFile(): Promise<string | null> {
   });
   if (typeof result === "string") return result;
   return null;
+}
+
+/**
+ * Native "Save As" dialog. Returns the chosen path or null on cancel.
+ * Used when the current buffer has no `activePath` yet (new untitled file)
+ * or when user explicitly wants to save-as to a new location.
+ */
+export async function pickSaveMarkdown(defaultPath?: string): Promise<string | null> {
+  const result = await save({
+    title: "save markdown",
+    defaultPath,
+    filters: [{ name: "markdown", extensions: ["md", "markdown", "mdx"] }],
+  });
+  return result ?? null;
 }
 
 const MARKDOWN_EXT = /\.(md|markdown|mdx)$/i;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -18,6 +18,7 @@ export { IS_MAC, IS_WINDOWS, IS_LINUX, displayKey, shortcutLabel } from "./platf
 export {
   pickFolder,
   pickMarkdownFile,
+  pickSaveMarkdown,
   listFolder,
   walkMarkdownFiles,
   readMarkdown,


### PR DESCRIPTION
## what

Two related bug fixes shipped as v1.3.5.

### 1. Save As for untitled buffers (resolves SAVE half of #17)

**Before**: pressing ⌘N → typing → ⌘S was a silent no-op because the save handler only fires when \`activePath\` is set. Reported by @arijit4 on Windows; reproduced by Matt on macOS.

**Now**:
- ⌘S on untitled buffer → opens native save dialog
- Default location: \`<rootPath>/untitled.md\` if a folder is open, else system default
- After save: \`activePath\` is set, future ⌘S writes to the same path
- NEW: **⌘⇧S** explicitly opens "Save As" on any buffer (untitled or existing)

### 2. PDF export now keeps syntax colors

**Before**: code blocks rendered in monospace but with no syntax highlighting in the exported PDF.

**Root cause**: the print stylesheet didn't include a rule mapping shiki's inline \`--shiki-{theme}\` CSS variables to actual colors. The live app has these in \`prose.css\` per-theme; the PDF stylesheet was missing them entirely.

**Fix**: added one rule that forces the catppuccin-latte palette for all PDF code blocks (light palette matches white PDF background).

## not in scope (separate)

- #17's folder-listing half (files not showing in sidebar on Windows) — pending Matt's DevTools investigation on his Windows machine

## test plan (macOS)

- [x] type-check passes
- [ ] ⌘N → type → ⌘S opens save dialog with \`untitled.md\` default
- [ ] save lands at chosen path, title bar updates, sidebar refreshes if file is inside rootPath
- [ ] ⌘⇧S re-opens dialog for save-as on existing files
- [ ] cancel dialog → no-op, no error
- [ ] PDF export shows colored code blocks (latte palette)

Matt to confirm manual test before tag is pushed.