### PR TITLE
feat(v1.3.6): task-list checkboxes (#21) + session restore (#22) + vim mode (#23)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@codemirror/view": "^6.42.1",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@replit/codemirror-vim": "^6.3.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
@@ -194,6 +195,8 @@
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
+
+    "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@codemirror/view": "^6.42.1",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@replit/codemirror-vim": "^6.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.5",
+  "version": "1.3.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.5"
+version = "1.3.6"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,7 @@ import {
   isMarkdownPath,
   joinPath,
   listFolder,
+  pathExists,
   moveEntry,
   pickFolder,
   pickMarkdownFile,
@@ -501,6 +502,36 @@ export function App() {
     }
   }, [activePath]);
   useFileWatcher(activePath, handleExternalChange);
+
+  // session restore (#22) — on app mount, if a file was open in the previous
+  // session, load it. uses the persisted `activePath` from usePersistedState
+  // (STORAGE_KEYS.lastFile). gracefully falls back to demo content if the file
+  // was deleted between sessions.
+  // mount-only on purpose — we do NOT re-fire when activePath changes, because
+  // that's normal file-switching during a session (handled by loadFile already).
+  useEffect(() => {
+    if (!activePath) return; // no persisted file → demo content stays
+    let cancelled = false;
+    void (async () => {
+      try {
+        const exists = await pathExists(activePath);
+        if (cancelled) return;
+        if (exists) {
+          void loadFile(activePath);
+        } else {
+          // stale path — file deleted between sessions, clear silently
+          setActivePath(null);
+        }
+      } catch (err) {
+        console.warn("marka.md: session restore failed", err);
+        if (!cancelled) setActivePath(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // mark dirty as soon as content diverges from disk
   useEffect(() => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -105,6 +105,7 @@ export function App() {
     if (stack.length > 20) stack.shift();
   }, []);
   const [welcomed, setWelcomed] = usePersistedState<boolean>(STORAGE_KEYS.welcomed, false);
+  const [vimOn, setVimOn] = usePersistedState<boolean>(STORAGE_KEYS.vimMode, false);
   const [welcomeOpen, setWelcomeOpen] = useState(!welcomed);
   const [dragActive, setDragActive] = useState(false);
   const [loadError, setLoadError] = useState<{ message: string; path?: string } | null>(null);
@@ -1101,6 +1102,8 @@ export function App() {
         onCopyMarkdown={activePath || source ? () => void copyMarkdown() : undefined}
         copyPulse={copyPulse}
         onExportPdf={exportToPdf}
+        vimOn={vimOn}
+        onToggleVim={() => setVimOn((v: boolean) => !v)}
       />
 
       <Breadcrumb
@@ -1148,7 +1151,7 @@ export function App() {
               treeVersion={treeVersion}
             />
             <Splitter
-              left={<Editor value={source} onChange={setSource} />}
+              left={<Editor value={source} onChange={setSource} vimOn={vimOn} />}
               right={<Preview source={debouncedPreview} />}
             />
           </>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -517,9 +517,9 @@ export function App() {
       try {
         const exists = await pathExists(activePath);
         if (cancelled) return;
-        if (exists) {
+        if (exists && !cancelled) {
           void loadFile(activePath);
-        } else {
+        } else if (!exists) {
           // stale path — file deleted between sessions, clear silently
           setActivePath(null);
         }
@@ -1103,7 +1103,7 @@ export function App() {
         copyPulse={copyPulse}
         onExportPdf={exportToPdf}
         vimOn={vimOn}
-        onToggleVim={() => setVimOn((v: boolean) => !v)}
+        onToggleVim={() => setVimOn((v) => !v)}
       />
 
       <Breadcrumb

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -259,6 +259,15 @@ export function App() {
       hr { border: none; border-top: 1px solid var(--pborder); margin: 2em 0; }
       ul, ol { padding-left: 24px; }
       li { margin: 0.25em 0; }
+      /* task lists in PDF — hide bullet, checkbox is the marker (#21) */
+      .task-list-item { list-style: none; margin-left: -1.4em; }
+      .task-list-item input[type="checkbox"] {
+        margin-right: 0.5em;
+        accent-color: var(--paccent);
+        width: 0.95em;
+        height: 0.95em;
+        vertical-align: -0.1em;
+      }
       table { border-collapse: collapse; width: 100%; }
       th, td { border: 1px solid var(--pborder); padding: 8px 12px; text-align: left; vertical-align: top; }
       th { background: rgba(0, 0, 0, 0.03); font-weight: 600; }

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -21,15 +21,15 @@ import { getSystemTheme, previewTheme, shortcutLabel, startWindowDrag, useThemeM
 
 type TitleBarProps = {
   fileName?: string;
-  /** full path of the active file — shown on hover over the centered filename */
   filePath?: string | null;
   dirty?: boolean;
   readingMode?: boolean;
   onToggleReading?: () => void;
-  /** shown in title-bar only while reading mode is on */
   onCopyMarkdown?: () => void;
   copyPulse?: boolean;
   onExportPdf?: () => void;
+  vimOn?: boolean;
+  onToggleVim?: () => void;
 };
 
 type ThemeChoice = { value: ThemeMode; label: string; icon: typeof Sun };
@@ -47,6 +47,8 @@ const THEME_CHOICES: ThemeChoice[] = [
 ];
 
 export function TitleBar({
+  vimOn = false,
+  onToggleVim,
   fileName,
   filePath,
   dirty = false,
@@ -222,6 +224,21 @@ export function TitleBar({
                   aria-valuetext={`${100 - opacity} percent transparent`}
                 />
               </div>
+              {onToggleVim ? (
+                <button
+                  type="button"
+                  className={`mdv-menu__item${vimOn ? " is-active" : ""}`}
+                  onClick={onToggleVim}
+                  role="menuitemcheckbox"
+                  aria-checked={vimOn}
+                >
+                  <span className="mdv-menu__item-icon" aria-hidden>
+                    <span className="mdv-menu__vim-badge">VIM</span>
+                  </span>
+                  <span className="mdv-menu__item-label">vim mode</span>
+                  <span className={`mdv-menu__switch${vimOn ? " is-on" : ""}`} aria-hidden />
+                </button>
+              ) : null}
             </div>
           </Popover>
         </div>

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -14,6 +14,7 @@ import {
   Sparkles,
   Sun,
   Sunset,
+  Terminal,
   Waves,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
@@ -225,19 +226,23 @@ export function TitleBar({
                 />
               </div>
               {onToggleVim ? (
-                <button
-                  type="button"
-                  className={`mdv-menu__item${vimOn ? " is-active" : ""}`}
-                  onClick={onToggleVim}
-                  role="menuitemcheckbox"
-                  aria-checked={vimOn}
-                >
-                  <span className="mdv-menu__item-icon" aria-hidden>
-                    <span className="mdv-menu__vim-badge">VIM</span>
-                  </span>
-                  <span className="mdv-menu__item-label">vim mode</span>
-                  <span className={`mdv-menu__switch${vimOn ? " is-on" : ""}`} aria-hidden />
-                </button>
+                <>
+                  <div className="mdv-menu__divider" aria-hidden />
+                  <div className="mdv-menu__label">editor</div>
+                  <button
+                    type="button"
+                    className={`mdv-menu__item${vimOn ? " is-active" : ""}`}
+                    onClick={onToggleVim}
+                    role="menuitemcheckbox"
+                    aria-checked={vimOn}
+                  >
+                    <span className="mdv-menu__item-icon">
+                      <Icon icon={Terminal} size={14} strokeWidth={1.5} />
+                    </span>
+                    <span className="mdv-menu__item-label">vim mode</span>
+                    <span className={`mdv-menu__switch${vimOn ? " is-on" : ""}`} aria-hidden />
+                  </button>
+                </>
               ) : null}
             </div>
           </Popover>

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -147,20 +147,20 @@ export function Editor({ value, onChange, vimOn = false }: EditorProps) {
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
+    const compartment = vimCompartment.current;
     let cancelled = false;
     if (vimOn) {
-      void import("@replit/codemirror-vim").then(({ vim }) => {
-        if (cancelled || !viewRef.current) return;
-        viewRef.current.dispatch({
-          effects: vimCompartment.current.reconfigure(vim()),
+      void import("@replit/codemirror-vim")
+        .then(({ vim }) => {
+          if (cancelled) return;
+          view.dispatch({ effects: compartment.reconfigure(vim()) });
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          console.error("marka.md: failed to load vim mode", err);
         });
-      }).catch((err) => {
-        console.error("marka.md: failed to load vim mode", err);
-      });
     } else {
-      view.dispatch({
-        effects: vimCompartment.current.reconfigure([]),
-      });
+      view.dispatch({ effects: compartment.reconfigure([]) });
     }
     return () => {
       cancelled = true;

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { EditorState } from "@codemirror/state";
+import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers, highlightActiveLine, drawSelection } from "@codemirror/view";
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { HighlightStyle, syntaxHighlighting, bracketMatching } from "@codemirror/language";
@@ -28,6 +28,8 @@ const mdHighlight = HighlightStyle.define([
 type EditorProps = {
   value: string;
   onChange: (next: string) => void;
+  /** opt-in vim keybindings (lazy-loaded on first true) */
+  vimOn?: boolean;
 };
 
 function buildTheme() {
@@ -82,11 +84,14 @@ function buildTheme() {
   );
 }
 
-export function Editor({ value, onChange }: EditorProps) {
+export function Editor({ value, onChange, vimOn = false }: EditorProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  // Compartment lets us swap the vim extension at runtime without rebuilding
+  // the EditorState (preserves doc, history, selection, undo stack).
+  const vimCompartment = useRef(new Compartment());
 
   useEffect(() => {
     if (!hostRef.current) return;
@@ -103,6 +108,8 @@ export function Editor({ value, onChange }: EditorProps) {
         markdown(),
         EditorView.lineWrapping,
         search({ top: true }),
+        // vim slot — empty until user toggles vimOn (#23)
+        vimCompartment.current.of([]),
         keymap.of([...defaultKeymap, ...historyKeymap, ...searchKeymap, indentWithTab]),
         buildTheme(),
         EditorView.updateListener.of((update) => {
@@ -133,6 +140,32 @@ export function Editor({ value, onChange }: EditorProps) {
       });
     }
   }, [value]);
+
+  // vim mode toggle (#23). Lazy-loads @replit/codemirror-vim on first enable
+  // so non-vim users don't pay the ~200KB cost. Persists across re-renders via
+  // the Compartment.reconfigure effect — doc + history are preserved.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    let cancelled = false;
+    if (vimOn) {
+      void import("@replit/codemirror-vim").then(({ vim }) => {
+        if (cancelled || !viewRef.current) return;
+        viewRef.current.dispatch({
+          effects: vimCompartment.current.reconfigure(vim()),
+        });
+      }).catch((err) => {
+        console.error("marka.md: failed to load vim mode", err);
+      });
+    } else {
+      view.dispatch({
+        effects: vimCompartment.current.reconfigure([]),
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [vimOn]);
 
   return <div ref={hostRef} className="mdv-editor" />;
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,6 +8,7 @@ export const STORAGE_KEYS = {
   lastFile: "mdview.lastFile",
   welcomed: "mdview.welcomed",
   recentFiles: "mdview.recent.files",
+  vimMode: "mdview.vim",
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -279,6 +279,22 @@
   margin-top: 0.25em;
 }
 
+/* task-list rows (markdown-it-task-lists) — hide the bullet so the checkbox is
+   the visual marker. Without this, both a • and a checkbox render, which looks
+   broken. (#21) */
+.mdv-prose .task-list-item {
+  list-style: none;
+  margin-left: -1.4em;
+}
+.mdv-prose .task-list-item input[type="checkbox"] {
+  margin-right: 0.5em;
+  accent-color: var(--accent);
+  width: 0.95em;
+  height: 0.95em;
+  vertical-align: -0.1em;
+  cursor: default;
+}
+
 .mdv-prose hr {
   border: 0;
   border-top: 1px solid var(--border);

--- a/src/styles/shared/menu.css
+++ b/src/styles/shared/menu.css
@@ -272,3 +272,19 @@
   outline-offset: 4px;
   border-radius: 8px;
 }
+
+.mdv-menu__vim-badge {
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  line-height: 1;
+}
+.mdv-menu__item.is-active .mdv-menu__vim-badge {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}

--- a/src/styles/shared/menu.css
+++ b/src/styles/shared/menu.css
@@ -273,18 +273,3 @@
   border-radius: 8px;
 }
 
-.mdv-menu__vim-badge {
-  font-family: var(--font-mono);
-  font-size: 8.5px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  padding: 2px 4px;
-  border-radius: 3px;
-  border: 1px solid var(--border);
-  color: var(--muted);
-  line-height: 1;
-}
-.mdv-menu__item.is-active .mdv-menu__vim-badge {
-  color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
-}


### PR DESCRIPTION
## what

bundles 3 fixes/features filed by @arijit4 in the past 24 hours.

### #21 — fix: task-list checkboxes hide bullets
\`- [ ]\` / \`- [x]\` rows now render with just the checkbox + label (no bullet beside it). applies to live preview AND PDF export. Checkbox accent color follows the active theme.

### #22 — fix: session restore on launch
Previously the app always opened with the demo file. Now it restores the last open file (using the already-persisted \`activePath\`). Gracefully falls back to demo if the file was deleted between sessions.

### #23 — feat: vim mode (opt-in)
\`@replit/codemirror-vim\` package, **lazy-loaded** on first toggle-on (non-vim users don't pay the ~200KB cost). Persists across launches. Toggle lives in the theme menu under a new "editor" section header — uses \`Terminal\` icon to match the rest of the menu's aesthetic.

## code review pass included
- HIGH: tightened cancelled-flag race in session-restore (\`app.tsx\`)
- MED: snapshot \`view\` in vim effect, removed double-deref of \`viewRef.current\`
- LOW: dropped redundant type annotation on toggle callback

## what this does NOT do

- vim mode status-bar pill (showing NORMAL/INSERT) — parked for v1.4.0
- vim \`:w\` / \`:q\` command bindings — package defaults only

## test plan (verified locally on macOS)

- [x] type-check clean
- [x] task-list rendering (live + PDF) — no bullets, checkbox styled
- [x] session restore — quits + relaunches to last file
- [x] vim mode — lazy-loads on first toggle, NORMAL/INSERT modes work, persists