### PR TITLE
chore(v1.3.7): readability pass — trim verbose comments + extract pdf-export + prune dead deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.6"
+version = "1.3.7"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,7 +24,6 @@ import { TooltipRoot } from "@/components/primitives";
 import { useDebouncedValue, useFileWatcher, usePersistedState, useShortcuts, useSyncScroll } from "@/hooks";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
-import { tempDir } from "@tauri-apps/api/path";
 import { openPath } from "@tauri-apps/plugin-opener";
 import {
   basename,
@@ -33,12 +32,14 @@ import {
   createMarkdownFile,
   dirname,
   estimateTokens,
+  exportPreviewToPdf,
   FS_CONFLICT,
   isMarkdownPath,
   joinPath,
   listFolder,
   pathExists,
   moveEntry,
+  PdfExportError,
   pickFolder,
   pickMarkdownFile,
   pickSaveMarkdown,
@@ -60,15 +61,6 @@ type UndoOp =
   | { kind: "rename"; from: string; to: string }
   | { kind: "create-folder"; path: string }
   | { kind: "create-file"; path: string };
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 export function App() {
   const [source, setSource] = useState<string>(DEMO_MARKDOWN);
@@ -148,186 +140,17 @@ export function App() {
   }, [setSidebarOpen]);
 
   const exportToPdf = useCallback(async () => {
-    // workaround: Tauri 2's WKWebView no-ops window.print(). instead, clone
-    // the already-rendered preview article (which has mermaid svgs, katex
-    // html, and shiki spans already painted), wrap in a standalone html
-    // doc with print-friendly styles, write to OS temp dir, open in the
-    // user's default browser. the browser auto-triggers its print dialog
-    // on load — user picks "Save as PDF" → real native flow.
-    if (!source.trim()) {
-      setLoadError({
-        message: "nothing to export. open or write some markdown first.",
-      });
-      return;
-    }
-
-    const article = document.querySelector<HTMLElement>(".mdv-prose");
-    if (!article) {
-      setLoadError({
-        message: "preview isn't rendered yet. try again in a moment.",
-      });
-      return;
-    }
-
-    const fileName = activePath ? basename(activePath) : undefined;
-    const title = fileName ?? "marka.md export";
-
-    // self-contained print stylesheet — light theme regardless of app theme.
-    // tracks the live prose CSS conceptually but stays decoupled so the
-    // exported pdf has a stable "document" look.
-    const printStyles = `
-      *, *::before, *::after { box-sizing: border-box; }
-      :root {
-        --pfg: #1d1d1f;
-        --pmuted: #6e6e73;
-        --paccent: #e2722e;
-        --pborder: rgba(0, 0, 0, 0.08);
-      }
-      html, body {
-        background: #fff;
-        color: var(--pfg);
-        font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", system-ui, sans-serif;
-        font-size: 15px;
-        line-height: 1.65;
-        margin: 0;
-        padding: 0;
-        -webkit-font-smoothing: antialiased;
-        /* preserve colors when saving to pdf (e.g. shiki code-block backgrounds) */
-        -webkit-print-color-adjust: exact;
-        print-color-adjust: exact;
-      }
-      .doc { max-width: 720px; margin: 0 auto; padding: 18mm 16mm 22mm; }
-      h1, h2, h3, h4 {
-        font-weight: 600;
-        letter-spacing: -0.018em;
-        /* keep headings on the same page as the first paragraph that follows */
-        break-after: avoid;
-        page-break-after: avoid;
-      }
-      h1 { font-size: 2.1em; margin: 0 0 0.5em; }
-      h2 { font-size: 1.55em; margin: 2em 0 0.5em; }
-      h3 { font-size: 1.25em; margin: 1.6em 0 0.5em; }
-      h4 { font-size: 1em; margin: 1.4em 0 0.4em; }
-      p, ul, ol, blockquote, pre, table { margin: 0 0 1em; }
-      p { orphans: 3; widows: 3; }
-      a {
-        color: var(--paccent);
-        text-decoration: none;
-        border-bottom: 1px solid color-mix(in srgb, var(--paccent) 30%, transparent);
-      }
-      code {
-        font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
-        font-size: 0.88em;
-        background: rgba(0, 0, 0, 0.045);
-        padding: 1px 6px;
-        border-radius: 4px;
-      }
-      pre {
-        font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
-        font-size: 12.5px;
-        line-height: 1.55;
-        background: #fafafa;
-        border: 1px solid var(--pborder);
-        border-radius: 8px;
-        padding: 14px 16px;
-        overflow-x: auto;
-        /* don't split code blocks across pages — looks bad and breaks tokens */
-        break-inside: avoid;
-        page-break-inside: avoid;
-      }
-      blockquote, table, .mdv-mermaid {
-        break-inside: avoid;
-        page-break-inside: avoid;
-      }
-      img { max-width: 100%; height: auto; border-radius: 6px; break-inside: avoid; }
-      pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; }
-      pre.shiki, pre.shiki * { font-family: inherit; }
-      /* PDF is a "document" — force catppuccin-latte palette regardless of
-         the user's active app theme. shiki emits --shiki-latte vars inline on
-         every span (multi-theme mode), so we just pick that variant for print.
-         Without this rule, spans would fall back to inherited body color
-         (looks like plain monospace text — no syntax colors). */
-      .shiki, .shiki span {
-        background-color: transparent !important;
-        color: var(--shiki-latte) !important;
-        font-style: var(--shiki-latte-font-style, inherit) !important;
-        font-weight: var(--shiki-latte-font-weight, inherit) !important;
-        text-decoration: var(--shiki-latte-text-decoration, inherit) !important;
-      }
-      blockquote {
-        border-left: 3px solid var(--paccent);
-        padding-left: 16px;
-        color: var(--pmuted);
-        font-style: italic;
-      }
-      hr { border: none; border-top: 1px solid var(--pborder); margin: 2em 0; }
-      ul, ol { padding-left: 24px; }
-      li { margin: 0.25em 0; }
-      /* task lists in PDF — hide bullet, checkbox is the marker (#21) */
-      .task-list-item { list-style: none; margin-left: -1.4em; }
-      .task-list-item input[type="checkbox"] {
-        margin-right: 0.5em;
-        accent-color: var(--paccent);
-        width: 0.95em;
-        height: 0.95em;
-        vertical-align: -0.1em;
-      }
-      table { border-collapse: collapse; width: 100%; }
-      th, td { border: 1px solid var(--pborder); padding: 8px 12px; text-align: left; vertical-align: top; }
-      th { background: rgba(0, 0, 0, 0.03); font-weight: 600; }
-      /* mermaid renders as inline SVG inside <pre class="mdv-mermaid"> */
-      .mdv-mermaid { background: transparent; border: 0; padding: 0; text-align: center; }
-      .mdv-mermaid svg { max-width: 100%; height: auto; }
-      /* hide in-app affordances that don't belong in print */
-      .mdv-copy, .mdv-codeblock > .mdv-copy { display: none !important; }
-      /* margin: 0 on @page leaves no room for the browser's auto header /
-         footer (title, date, url, page numbers). all visible whitespace is
-         pushed into .doc padding instead so it still looks like a margined
-         document. users can also uncheck "Headers and footers" in the print
-         dialog's "More settings" if their browser still tries to render them. */
-      @page { margin: 0; size: auto; }
-      @media print {
-        body { padding: 0; }
-        .doc { padding: 18mm 16mm 22mm; }
-      }
-    `;
-
-    const html = `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(title)}</title>
-  <style>${printStyles}</style>
-</head>
-<body>
-  <main class="doc">
-    ${article.outerHTML}
-  </main>
-  <script>
-    // auto-trigger the print dialog once layout settles
-    window.addEventListener("load", () => {
-      setTimeout(() => window.print(), 350);
-    });
-  </script>
-</body>
-</html>`;
-
     try {
-      const dir = (await tempDir()).replace(/[\\/]+$/, "");
-      const safeName = (fileName ?? "export")
-        .replace(/\.md$/i, "")
-        .replace(/[^\w.-]+/g, "-")
-        .slice(0, 60) || "export";
-      // stable name → overwrites on each export instead of piling up in /tmp
-      const tempPath = `${dir}/marka-${safeName}.html`;
-      await writeMarkdown(tempPath, html);
-      await openPath(tempPath);
+      await exportPreviewToPdf({ source, activePath });
     } catch (err) {
+      const message = err instanceof PdfExportError
+        ? err.message
+        : "couldn't export to pdf";
       console.error("marka.md: pdf export failed", err);
-      setLoadError({ message: "couldn't export to pdf — try again, or check disk space" });
+      setLoadError({ message });
     }
   }, [source, activePath]);
+
 
   const toggleFullscreen = useCallback(async () => {
     const win = getCurrentWindow();

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -55,6 +55,21 @@ import "./app.css";
 
 const SAVED_FLASH_MS = 1200;
 
+type UndoOp =
+  | { kind: "move"; from: string; to: string }
+  | { kind: "rename"; from: string; to: string }
+  | { kind: "create-folder"; path: string }
+  | { kind: "create-file"; path: string };
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export function App() {
   const [source, setSource] = useState<string>(DEMO_MARKDOWN);
   const [savedContent, setSavedContent] = useState<string>(DEMO_MARKDOWN);
@@ -92,12 +107,6 @@ export function App() {
   const [updateInstalling, setUpdateInstalling] = useState(false);
   const [updateUpToDate, setUpdateUpToDate] = useState(false);
 
-  // undo stack for sidebar file operations — ⌘⌥Z pops + reverses
-  type UndoOp =
-    | { kind: "move"; from: string; to: string }
-    | { kind: "rename"; from: string; to: string }
-    | { kind: "create-folder"; path: string }
-    | { kind: "create-file"; path: string };
   const undoStackRef = useRef<UndoOp[]>([]);
   const pushUndo = useCallback((op: UndoOp) => {
     const stack = undoStackRef.current;
@@ -134,8 +143,8 @@ export function App() {
     setSaveStatus("idle");
   }, [setActivePath]);
 
-  const handleToggleSidebarFromCommands = useCallback(() => {
-    setSidebarOpen((v) => !v);
+  const handleToggleSidebar = useCallback(() => {
+    setSidebarOpen((v: boolean) => !v);
   }, [setSidebarOpen]);
 
   const exportToPdf = useCallback(async () => {
@@ -162,13 +171,6 @@ export function App() {
 
     const fileName = activePath ? basename(activePath) : undefined;
     const title = fileName ?? "marka.md export";
-    const escapeHtml = (s: string): string =>
-      s
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
 
     // self-contained print stylesheet — light theme regardless of app theme.
     // tracks the live prose CSS conceptually but stays decoupled so the
@@ -496,11 +498,10 @@ export function App() {
       try {
         const exists = await pathExists(activePath);
         if (cancelled) return;
-        if (exists && !cancelled) {
+        if (exists) {
           void loadFile(activePath);
-        } else if (!exists) {
-          // stale path — file deleted between sessions, clear silently
-          setActivePath(null);
+        } else {
+          setActivePath(null); // stale path — file deleted between sessions
         }
       } catch (err) {
         console.warn("marka.md: session restore failed", err);
@@ -550,10 +551,6 @@ export function App() {
       editor?.focus();
     });
   }, [setActivePath]);
-
-  const handleToggleSidebar = useCallback(() => {
-    setSidebarOpen(!sidebarOpen);
-  }, [setSidebarOpen, sidebarOpen]);
 
   const handleMove = useCallback(
     async (src: string, dstParent: string) => {
@@ -984,7 +981,6 @@ export function App() {
         : {}),
     }),
     [
-      sidebarOpen,
       activePath,
       source,
       savedContent,
@@ -993,14 +989,10 @@ export function App() {
       handleOpenFile,
       handleOpenFolder,
       handleNewFile,
-      handleToggleSidebarFromCommands,
-      showHelp,
-      showWelcome,
+      handleToggleSidebar,
       copyMarkdown,
       exportToPdf,
       toggleFullscreen,
-      loadFile,
-      recentFiles,
       readingMode,
       toggleReadingMode,
       exitReadingMode,
@@ -1019,7 +1011,7 @@ export function App() {
             void saveNow(activePath, source);
           }
         },
-        toggleSidebar: handleToggleSidebarFromCommands,
+        toggleSidebar: handleToggleSidebar,
         toggleReading: toggleReadingMode,
         showHelp,
         showWelcome,
@@ -1045,7 +1037,6 @@ export function App() {
       savedContent,
       saveNow,
       sidebarOpen,
-      setSidebarOpen,
       copyMarkdown,
       showHelp,
       showWelcome,
@@ -1055,7 +1046,7 @@ export function App() {
       handleManualUpdateCheck,
       exportToPdf,
       toggleFullscreen,
-      handleToggleSidebarFromCommands,
+      handleToggleSidebar,
       loadFile,
       recentFiles,
     ],

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -346,9 +346,7 @@ export function App() {
   const toggleReadingMode = useCallback(() => setReadingMode((v) => !v), []);
   const exitReadingMode = useCallback(() => setReadingMode(false), []);
 
-  // ⌘F find in reading mode (v1.2.0). Codemirror handles its own ⌘F in editor
-  // mode; we only bind the shortcut while reading is active. proseRef captures
-  // the rendered article element so the find component can walk text nodes.
+  // ⌘F only bound while reading — CM owns it in editor mode.
   const [findOpen, setFindOpen] = useState(false);
   const [proseEl, setProseEl] = useState<HTMLElement | null>(null);
   useEffect(() => {
@@ -364,8 +362,6 @@ export function App() {
     return () => window.cancelAnimationFrame(id);
   }, [readingMode]);
 
-  // external-edit watcher (v1.2.0): poll the active file's mtime and offer to
-  // reload when it changes outside marka.md (vim, vscode, etc).
   const [externalReloadToast, setExternalReloadToast] = useState(false);
   const [externalConflict, setExternalConflict] = useState<string | null>(null);
 
@@ -445,12 +441,6 @@ export function App() {
     [],
   );
 
-  // Save As — opens the native save dialog and writes the buffer to the
-  // chosen path. Used by:
-  //   - ⌘S when the current buffer is untitled (no activePath) — previously
-  //     this was a no-op on all platforms (the bug arijit4 reported in #17
-  //     and Matt confirmed on macOS)
-  //   - ⌘⇧S explicitly, to "save a copy" of an existing file to a new location
   const saveAs = useCallback(async () => {
     // suggest a default location: <rootPath>/untitled.md if a folder is open,
     // else just "untitled.md" (dialog will land in the OS default folder)
@@ -467,10 +457,7 @@ export function App() {
     window.setTimeout(() => setSaveAsToast(null), 2400);
   }, [activePath, rootPath, source, saveNow, setActivePath]);
 
-  // refs to source + savedContent so handleExternalChange has stable identity.
-  // without this, every keystroke recreates the callback → useFileWatcher's
-  // effect tears down + restarts the 2s interval, adding a stat() call per
-  // keystroke and risking missed external edits during the restart window.
+  // stable refs so handleExternalChange identity doesn't fluctuate with keystrokes.
   const sourceRef = useRef(source);
   const savedRef = useRef(savedContent);
   useEffect(() => {
@@ -480,10 +467,7 @@ export function App() {
     savedRef.current = savedContent;
   }, [savedContent]);
 
-  // external-change handler: re-read the file when its mtime ticks. if user
-  // has no unsaved changes, silently reload + show a brief toast. if they DO
-  // have dirty edits, surface a conflict toast and let them choose.
-  // Stable dep set ([activePath]) — watcher only rebinds when file changes.
+  // stable dep set — watcher only rebinds when active file changes.
   const handleExternalChange = useCallback(async () => {
     if (!activePath) return;
     try {
@@ -504,12 +488,7 @@ export function App() {
   }, [activePath]);
   useFileWatcher(activePath, handleExternalChange);
 
-  // session restore (#22) — on app mount, if a file was open in the previous
-  // session, load it. uses the persisted `activePath` from usePersistedState
-  // (STORAGE_KEYS.lastFile). gracefully falls back to demo content if the file
-  // was deleted between sessions.
-  // mount-only on purpose — we do NOT re-fire when activePath changes, because
-  // that's normal file-switching during a session (handled by loadFile already).
+  // mount-only: restore last open file from persisted activePath. eslint-disable below is intentional.
   useEffect(() => {
     if (!activePath) return; // no persisted file → demo content stays
     let cancelled = false;
@@ -713,10 +692,7 @@ export function App() {
     }
   }, [activePath, bumpTree, setActivePath]);
 
-  // ⌘⌥Z (macOS) / Ctrl+Alt+Z (Windows/Linux) global keybinding for file-op undo
-  // (doesn't clash with editor ⌘Z / Ctrl+Z). Option/Alt modifies the produced
-  // character on macOS (⌥Z = Ω), so we match on e.code which reflects the
-  // physical key independent of modifiers.
+  // ⌥Z produces Ω on macOS — match e.code, not e.key.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -850,10 +826,8 @@ export function App() {
     }
   }, []);
 
-  // OS file drops via HTML5 (Tauri's dragDropEnabled is OFF so the OS-level
-  // intercept doesn't fight with the in-app sidebar drag-and-drop).
-  // counter pattern: nested elements fire dragenter/leave multiple times, so we
-  // increment on enter and decrement on leave. only show overlay when count > 0.
+  // OS drop. dragDropEnabled is OFF so Tauri doesn't intercept. counter guards
+  // nested dragenter/leave firing multiple times.
   useEffect(() => {
     let enterCount = 0;
 
@@ -1218,8 +1192,6 @@ export function App() {
         onDismiss={() => setUpdateUpToDate(false)}
       />
 
-      {/* external-edit watcher: silent reload toast when file changed on disk
-          and we had no unsaved local changes. */}
       <Toast
         open={externalReloadToast && loadError == null}
         message="file changed externally · reloaded"
@@ -1227,8 +1199,6 @@ export function App() {
         onDismiss={() => setExternalReloadToast(false)}
       />
 
-      {/* external-edit watcher: conflict toast when external change collides
-          with dirty local edits. user picks which version wins. */}
       <Toast
         open={externalConflict != null && loadError == null}
         message="this file changed externally · your unsaved edits would be lost"

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -63,10 +63,6 @@ export function TitleBar({
   const { opacity, on: transparent, set: setTransparency } = useTransparency();
   const [menuOpen, setMenuOpen] = useState(false);
   const themeAnchorRef = useRef<HTMLDivElement>(null);
-  // hover = preview only (DOM-level, no storage write).
-  // moving between items keeps the preview (no flash).
-  // mouse-leave the ENTIRE menu OR popover close = revert to stored.
-  // click = commit (setMode → writes storage + applies).
   const hoverTimer = useRef<number | null>(null);
   const resolveThemeForPreview = (value: ThemeMode): Theme =>
     value === "system" ? getSystemTheme() : value;
@@ -78,8 +74,6 @@ export function TitleBar({
     }, 60);
   };
   const cancelHoverTimer = () => {
-    // cancel a PENDING preview without reverting — used when cursor leaves an
-    // item but is still inside the menu (moving to another item).
     if (hoverTimer.current !== null) {
       window.clearTimeout(hoverTimer.current);
       hoverTimer.current = null;
@@ -90,8 +84,6 @@ export function TitleBar({
     previewTheme(null);
   };
 
-  // ActiveIcon is the resolved theme's icon (single source of truth: THEME_CHOICES).
-  // Avoids drift when adding new themes — add one entry to THEME_CHOICES, done.
   const ActiveIcon =
     mode === "system"
       ? Monitor

--- a/src/components/primitives/button.tsx
+++ b/src/components/primitives/button.tsx
@@ -7,13 +7,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   iconRight?: ReactNode;
 };
 
-/**
- * Base button. Two variants — `ghost` (default, transparent with hover) and
- * `solid` (accent-filled CTA). Pair `icon` (or `iconRight`) + optional `children`.
- *
- * <Button icon={<Icon icon={Save} />} title="save (⌘S)" onClick={save} />
- * <Button iconRight={<Icon icon={ChevronRight} />}>next</Button>
- */
+/** Ghost (default) or solid variant. Accepts icon, iconRight, children. */
 export function Button({
   variant = "ghost",
   size = "sm",

--- a/src/hooks/use-file-watcher.ts
+++ b/src/hooks/use-file-watcher.ts
@@ -2,14 +2,8 @@ import { useEffect } from "react";
 import { stat } from "@tauri-apps/plugin-fs";
 
 /**
- * Polls the file's mtime every 2s while the window is focused, fires onChange()
- * when the mtime ticks. Stops automatically on path change, unmount, or when
- * the window loses focus (resumes on refocus with an immediate check).
- *
- * Simple polling beats a full FS-watch plugin here because:
- *   - markdown files are small + reads are cheap
- *   - we already need user-focused polling (window blur = pause)
- *   - no new rust deps
+ * Polls mtime every 2s. Pauses on blur, resumes on focus.
+ * Picked over tauri-plugin-fs-watch: md files are cheap, no new rust deps.
  */
 export function useFileWatcher(path: string | null, onChange: () => void): void {
   useEffect(() => {

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -27,11 +27,7 @@ export async function pickMarkdownFile(): Promise<string | null> {
   return null;
 }
 
-/**
- * Native "Save As" dialog. Returns the chosen path or null on cancel.
- * Used when the current buffer has no `activePath` yet (new untitled file)
- * or when user explicitly wants to save-as to a new location.
- */
+/** Native "Save As" dialog. Returns path or null on cancel. */
 export async function pickSaveMarkdown(defaultPath?: string): Promise<string | null> {
   const result = await save({
     title: "save markdown",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,6 +14,7 @@ export { STORAGE_KEYS, type StorageKey } from "./storage";
 export { buildCommands, type Command, type CommandActions } from "./commands";
 export { estimateTokens, formatTokens } from "./bundle";
 export { startWindowDrag } from "./window-drag";
+export { exportPreviewToPdf, PdfExportError } from "./pdf-export";
 export { IS_MAC, IS_WINDOWS, IS_LINUX, displayKey, shortcutLabel } from "./platform";
 export {
   pickFolder,

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,17 +3,12 @@ import taskLists from "markdown-it-task-lists";
 import { createHighlighter, type Highlighter } from "shiki";
 import type { Theme } from "./theme";
 
-// random suffix per mermaid block — avoids id collisions when html re-renders
-// (which happens on save, reading-mode toggle, theme switch). Mermaid creates
-// a temporary <svg id="${id}-svg"> in document.body and tearing down the old
-// pre while the new render uses the same id was causing silent failures.
+// random suffix per render — mermaid id reuse across re-renders silently fails.
 function mermaidId(): string {
   return `mdv-mermaid-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-// expanded language list — covers the long tail of code blocks users actually
-// paste from their AI context (resolves #18: c/java/cpp were missing).
-// Shiki lazy-loads grammars; listing more here just registers them eagerly.
+// shiki lazy-loads grammars; registering all here for eager load.
 const LANGS = [
   // existing
   "markdown", "ts", "tsx", "js", "jsx", "json", "rust", "bash", "css", "html", "python", "go",
@@ -92,9 +87,7 @@ const md = new MarkdownIt({
     try {
       return highlighter.codeToHtml(code, {
         lang: language,
-        // pass full THEMES map so EVERY registered theme gets a css-var variant
-        // (kanagawa / rose-pine / ayu were missing before, so code blocks fell
-        // back to no-color when active theme didn't have a variant).
+        // pass all themes so every variant gets a css-var; defaultColor:false uses them.
         themes: THEMES,
         defaultColor: false,
       });

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -1,0 +1,183 @@
+import { tempDir } from "@tauri-apps/api/path";
+import { openPath } from "@tauri-apps/plugin-opener";
+import { basename, writeMarkdown } from "./files";
+
+// Tauri 2's WKWebView no-ops window.print(). We clone the rendered preview
+// article + wrap in a standalone html doc, write to OS temp, open in default
+// browser. Browser auto-prints on load → user saves as PDF.
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Light-theme print stylesheet. PDF is a "document" — force catppuccin-latte
+// palette regardless of app theme so colors are consistent on white.
+const PRINT_STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  :root {
+    --pfg: #1d1d1f;
+    --pmuted: #6e6e73;
+    --paccent: #e2722e;
+    --pborder: rgba(0, 0, 0, 0.08);
+  }
+  html, body {
+    background: #fff;
+    color: var(--pfg);
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", system-ui, sans-serif;
+    font-size: 15px;
+    line-height: 1.65;
+    margin: 0;
+    padding: 0;
+    -webkit-font-smoothing: antialiased;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .doc { max-width: 720px; margin: 0 auto; padding: 18mm 16mm 22mm; }
+  h1, h2, h3, h4 {
+    font-weight: 600;
+    letter-spacing: -0.018em;
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+  h1 { font-size: 2.1em; margin: 0 0 0.5em; }
+  h2 { font-size: 1.55em; margin: 2em 0 0.5em; }
+  h3 { font-size: 1.25em; margin: 1.6em 0 0.5em; }
+  h4 { font-size: 1em; margin: 1.4em 0 0.4em; }
+  p, ul, ol, blockquote, pre, table { margin: 0 0 1em; }
+  p { orphans: 3; widows: 3; }
+  a {
+    color: var(--paccent);
+    text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--paccent) 30%, transparent);
+  }
+  code {
+    font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.88em;
+    background: rgba(0, 0, 0, 0.045);
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
+  pre {
+    font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+    font-size: 12.5px;
+    line-height: 1.55;
+    background: #fafafa;
+    border: 1px solid var(--pborder);
+    border-radius: 8px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  blockquote, table, .mdv-mermaid {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  img { max-width: 100%; height: auto; border-radius: 6px; break-inside: avoid; }
+  pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; }
+  pre.shiki, pre.shiki * { font-family: inherit; }
+  /* shiki spans carry --shiki-{theme} vars inline; pick latte for print. */
+  .shiki, .shiki span {
+    background-color: transparent !important;
+    color: var(--shiki-latte) !important;
+    font-style: var(--shiki-latte-font-style, inherit) !important;
+    font-weight: var(--shiki-latte-font-weight, inherit) !important;
+    text-decoration: var(--shiki-latte-text-decoration, inherit) !important;
+  }
+  blockquote {
+    border-left: 3px solid var(--paccent);
+    padding-left: 16px;
+    color: var(--pmuted);
+    font-style: italic;
+  }
+  hr { border: none; border-top: 1px solid var(--pborder); margin: 2em 0; }
+  ul, ol { padding-left: 24px; }
+  li { margin: 0.25em 0; }
+  .task-list-item { list-style: none; margin-left: -1.4em; }
+  .task-list-item input[type="checkbox"] {
+    margin-right: 0.5em;
+    accent-color: var(--paccent);
+    width: 0.95em;
+    height: 0.95em;
+    vertical-align: -0.1em;
+  }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid var(--pborder); padding: 8px 12px; text-align: left; vertical-align: top; }
+  th { background: rgba(0, 0, 0, 0.03); font-weight: 600; }
+  .mdv-mermaid { background: transparent; border: 0; padding: 0; text-align: center; }
+  .mdv-mermaid svg { max-width: 100%; height: auto; }
+  .mdv-copy, .mdv-codeblock > .mdv-copy { display: none !important; }
+  /* margin:0 on @page suppresses browser auto-header/footer. .doc padding holds visible margin. */
+  @page { margin: 0; size: auto; }
+  @media print {
+    body { padding: 0; }
+    .doc { padding: 18mm 16mm 22mm; }
+  }
+`;
+
+export class PdfExportError extends Error {
+  constructor(
+    public readonly code: "empty" | "no-preview" | "io",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PdfExportError";
+  }
+}
+
+type ExportOpts = {
+  source: string;
+  activePath: string | null;
+};
+
+/** Export the live .mdv-prose article as a self-contained HTML and open in browser to print. */
+export async function exportPreviewToPdf({ source, activePath }: ExportOpts): Promise<void> {
+  if (!source.trim()) {
+    throw new PdfExportError("empty", "nothing to export. open or write some markdown first.");
+  }
+  const article = document.querySelector<HTMLElement>(".mdv-prose");
+  if (!article) {
+    throw new PdfExportError("no-preview", "preview isn't rendered yet. try again in a moment.");
+  }
+
+  const fileName = activePath ? basename(activePath) : undefined;
+  const title = fileName ?? "marka.md export";
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>${PRINT_STYLES}</style>
+</head>
+<body>
+  <main class="doc">
+    ${article.outerHTML}
+  </main>
+  <script>
+    window.addEventListener("load", () => {
+      setTimeout(() => window.print(), 350);
+    });
+  </script>
+</body>
+</html>`;
+
+  try {
+    const dir = (await tempDir()).replace(/[\\/]+$/, "");
+    const safeName = (fileName ?? "export")
+      .replace(/\.md$/i, "")
+      .replace(/[^\w.-]+/g, "-")
+      .slice(0, 60) || "export";
+    const tempPath = `${dir}/marka-${safeName}.html`;
+    await writeMarkdown(tempPath, html);
+    await openPath(tempPath);
+  } catch {
+    throw new PdfExportError("io", "couldn't export to pdf — try again, or check disk space");
+  }
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -6,11 +6,7 @@ export type UpdateCheckResult =
   | { status: "none" }
   | { status: "error"; message: string };
 
-/**
- * Talks to the Tauri updater (which fetches latest.json from GitHub
- * Releases and verifies the signature against the pubkey baked into the
- * app). Safe to call multiple times.
- */
+/** Checks GitHub Releases via Tauri updater; idempotent. */
 export async function checkForUpdate(): Promise<UpdateCheckResult> {
   try {
     const update = await check();
@@ -33,11 +29,7 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
   }
 }
 
-/**
- * Downloads + installs the latest update, then relaunches the app.
- * Throws on signature mismatch — the app refuses to install anything
- * not signed by our private updater key.
- */
+/** Throws on signature mismatch; relaunches on success. */
 export async function applyUpdate(
   onProgress?: (downloaded: number, total: number) => void,
 ): Promise<void> {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -133,11 +133,9 @@ button:focus-visible {
   background: color-mix(in srgb, var(--accent) 32%, transparent) !important;
 }
 
-/* print-to-pdf — body.mdv-print is added before window.print() so the
-   on-screen DOM is reshaped *before* the webview snapshots for the print
-   dialog. WKWebView often renders the live screen layout (not @media print)
-   into the PDF, so the class-based variant is the reliable path. The
-   @media print block stays as a belt-and-suspenders for stock browsers. */
+/* print-to-pdf — body.mdv-print is added before window.print() so the DOM is
+   reshaped *before* the webview snapshots. WKWebView often renders the live
+   screen layout (not @media print) into the PDF; class-based is the reliable path. */
 body.mdv-print .mdv-titlebar,
 body.mdv-print .mdv-breadcrumb,
 body.mdv-print .mdv-statusbar,

--- a/src/styles/shared/transparency.css
+++ b/src/styles/shared/transparency.css
@@ -1,13 +1,5 @@
-/* Ghostty-style window transparency.
-   When user opts in (slider < 100), ALL chrome surfaces become transparent so
-   the single rgba background on .mdv-app + the native macOS NSVisualEffect
-   vibrancy show through uniformly. Without this, each chrome row stacks its
-   own rgba layer on top of the shell, producing the "only 2 panes look
-   transparent" effect.
-
-   .mdv-app keeps its var(--bg) (which becomes rgba when transparency is on).
-   Surface popovers (menu, popover, palette) intentionally keep --surface so
-   they remain readable on top of the translucent background. */
+/* transparency: clear all chrome so NSVisualEffect shows through uniformly
+   (layered rgba would only translucent-ify 2 panes). popovers keep --surface intentionally. */
 
 :root[data-transparency="on"] .mdv-titlebar,
 :root[data-transparency="on"] .mdv-breadcrumb,


### PR DESCRIPTION
## what

Internal cleanup pass. **Zero user-facing changes.** Type-check clean. Matt verified all features still work locally.

### commits

1. **chore: trim verbose AI-style comments across src (-79 lines)** — removed AI-essay-style comment blocks, stale version-ref/issue-ref tags, and self-evident restatements. Kept genuine WHY/gotcha notes.
2. **refactor: hoist UndoOp + escapeHtml to module scope, dedupe sidebar toggle, prune dead deps** — `UndoOp` type moved out of component body. `escapeHtml` lifted to module scope. Two duplicate sidebar-toggle callbacks merged into one (fixed stale-closure pattern). Pruned 6 dead entries from `shortcuts` + `commands` useMemo deps arrays.
3. **refactor: extract pdf export to lib/pdf-export.ts (-177 lines in app.tsx)** — moved the 130-line `printStyles` template + html builder + write/open flow into a focused `lib/pdf-export.ts` module with a typed `PdfExportError`. `app.tsx`'s `exportToPdf` callback is now ~10 lines.

### impact

| metric | before | after |
|---|---|---|
| `app.tsx` lines | 1255 | **1078** (−177) |
| verbose comment lines stripped | — | ~79 |
| dead dep-array entries | 6 | 0 |

### tested locally (Matt)

- [x] PDF export (with mermaid + code blocks + checkboxes)
- [x] Session restore (quit + relaunch returns to last file)
- [x] Save As (⌘N → ⌘S, ⌘⇧S explicit)
- [x] Sidebar toggle (⌘B + breadcrumb button + palette command)
- [x] Vim mode (toggle on/off, hjkl works, persists)
- [x] Theme hover preview (no flash, commits on click)
- [x] Find in editor + reading mode

### what this does NOT do

- Big architectural refactors (`useEditorBuffer` / `useFileSidebar` hooks, `copyPulse`+`copyToast` merge) — parked for v1.4
- Any behavior change. This is purely "the same app, less code"