### PR TITLE
feat(v1.3.8): intel mac builds + ship deps bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            args: --target x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             args: ""
@@ -163,7 +166,8 @@ jobs:
 
             ## install
 
-            **macOS** (notarized + auto-updating): `marka.md.dmg` → drag to `/Applications`
+            **macOS Apple Silicon** (notarized + auto-updating): `marka.md.dmg` → drag to `/Applications`
+            **macOS Intel** (notarized + auto-updating): `marka.md_intel.dmg` → drag to `/Applications`
             **Windows**: `marka.md_*-setup.exe` → run (SmartScreen → "More info" → "Run anyway")
             **Linux** 🐧: pick `.AppImage` (any distro), `.deb` (Debian/Ubuntu), or `.rpm` (Fedora/RHEL)
 
@@ -185,28 +189,47 @@ jobs:
           prerelease: false
           args: ${{ matrix.args }}
 
-      # tauri-action emits `marka.md_<version>_<arch>.dmg` by default — too
-      # wordy. rename to `marka.md.dmg` via GH API (pure metadata change, no
-      # re-upload). macOS-only — Windows artifact names stay as
-      # `marka.md_<version>_x64-setup.exe` / `.msi` (Tauri convention).
-      - name: rename dmg → marka.md.dmg
-        if: matrix.os == 'macos-latest' && success()
+      # tauri-action emits `marka.md_<version>_<arch>.dmg` by default. Rename
+      # per arch so users get clean filenames + the landing dropdown can keep
+      # linking to `marka.md.dmg` (apple-silicon default). Intel gets a clear
+      # `_intel` suffix. Both rename steps are guarded by their matrix target
+      # so the two macOS legs don't race.
+      - name: rename dmg → marka.md.dmg (apple silicon)
+        if: matrix.target == 'aarch64-apple-darwin' && success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -e
-          # /releases/tags/<tag> 404s on draft releases. /releases lists all
-          # (incl. drafts) — filter by tag_name to find the right one.
           RELEASE_ID=$(gh api repos/${{ github.repository }}/releases --jq '.[] | select(.tag_name == "${{ github.ref_name }}") | .id' | head -1)
           if [ -z "$RELEASE_ID" ]; then
             echo "no release found for tag ${{ github.ref_name }} — skipping rename"
             exit 0
           fi
-          ASSET_ID=$(gh api "repos/${{ github.repository }}/releases/$RELEASE_ID/assets" --jq '.[] | select(.name | endswith(".dmg")) | .id' | head -1)
+          ASSET_ID=$(gh api "repos/${{ github.repository }}/releases/$RELEASE_ID/assets" --jq '.[] | select(.name | test("aarch64.*\\.dmg$")) | .id' | head -1)
           if [ -n "$ASSET_ID" ]; then
-            echo "renaming dmg asset $ASSET_ID → marka.md.dmg"
+            echo "renaming aarch64 dmg asset $ASSET_ID → marka.md.dmg"
             gh api "repos/${{ github.repository }}/releases/assets/$ASSET_ID" -X PATCH -f name='marka.md.dmg'
+          else
+            echo "no aarch64 dmg asset found — skipping rename"
+          fi
+
+      - name: rename dmg → marka.md_intel.dmg (intel)
+        if: matrix.target == 'x86_64-apple-darwin' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -e
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases --jq '.[] | select(.tag_name == "${{ github.ref_name }}") | .id' | head -1)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "no release found for tag ${{ github.ref_name }} — skipping rename"
+            exit 0
+          fi
+          ASSET_ID=$(gh api "repos/${{ github.repository }}/releases/$RELEASE_ID/assets" --jq '.[] | select(.name | test("x64.*\\.dmg$")) | .id' | head -1)
+          if [ -n "$ASSET_ID" ]; then
+            echo "renaming intel dmg asset $ASSET_ID → marka.md_intel.dmg"
+            gh api "repos/${{ github.repository }}/releases/assets/$ASSET_ID" -X PATCH -f name='marka.md_intel.dmg'
           else
             echo "no dmg asset found — skipping rename"
           fi

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ works with claude, chatgpt, gemini, your local agent — anywhere that reads pla
 
 [download the latest release →](https://github.com/mattenarle10/markamd/releases/latest)
 
-### macOS (apple silicon, notarized)
+### macOS (notarized + auto-updating, universal arch coverage)
 
-grab `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
+- **apple silicon** (M1/M2/M3/M4): grab `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
+- **intel mac**: grab `marka.md_intel.dmg` → same install steps.
 
 ### Windows (10+, x64)
 
@@ -99,7 +100,7 @@ shortcuts shown with **macOS** modifiers below. on **Windows / Linux**, substitu
 
 | layer | choice |
 |---|---|
-| shell | tauri 2 (rust + webview), apple silicon target |
+| shell | tauri 2 (rust + webview), macOS universal + Windows + Linux |
 | frontend | react 19 · vite 7 · typescript 5.8 · bun |
 | editor | codemirror 6 + `@codemirror/lang-markdown` + `@codemirror/search` |
 | markdown | markdown-it + shiki + mermaid |
@@ -134,7 +135,6 @@ per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 **next** (v1.4+):
 - **session restore** — remember last folder + open file + scroll position
 - **context tray** — multi-file bundling, ⌘-click to stage, copy as one prompt
-- **intel mac builds** (currently apple silicon only)
 
 contributions welcome — see [feedback](#feedback) below to suggest priorities.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.7"
+version = "1.3.8"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## what

Adds **intel mac** to the CI matrix so users on Intel macs can install marka.md. Also bundles 3 dependabot patches that landed earlier today.

### intel mac CI

- New matrix leg: \`x86_64-apple-darwin\` (alongside existing aarch64 + Windows + Linux = 4 parallel build legs).
- DMG renames split per arch:
  - apple silicon → \`marka.md.dmg\` (existing, unchanged for landing dropdown back-compat)
  - intel → \`marka.md_intel.dmg\` (new)
- Release body install lines updated.

### deps already on main (just being released)

- tauri 2.11.1 → 2.11.2 (#10)
- tauri-build 2.6.1 → 2.6.2 (#11)
- typescript 5.8.3 → 5.9.3 (#12)

### README

- macOS install section now shows both apple silicon + intel
- removed "intel mac builds" from planned roadmap (ships in this release)

### landing site (separate PR — markamd-site)

- Adds \`macIntelUrl\` to Release type + asset finder
- New "macOS · intel" row in download dropdown (greyed "soon" until v1.3.8 publishes)

## test plan

- [x] type-check passes (mdview)
- [x] markamd-site build passes
- [ ] CI builds all 4 legs once tagged
- [ ] Apple Silicon mac still gets \`marka.md.dmg\` (matches landing dropdown)
- [ ] Intel mac gets \`marka.md_intel.dmg\`
- [ ] Existing aarch64 users auto-update normally (latest.json unchanged for aarch64)

## risks

- 2 parallel macOS legs share `macos-latest` runner pool — no GitHub Actions limit issue
- Notarization runs on both legs (Apple Developer ID is universal) — same cert flow
- Auto-updater latest.json now has both \`darwin-x86_64\` + \`darwin-aarch64\` entries; existing aarch64 users see the aarch64 update, intel users see the intel one