### PR TITLE
v1.4.0 — lazy shiki (~260MB ram reduction)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.3.8",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.3.8"
+version = "1.4.0"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ensureMarkdownReady, renderMarkdown, useTheme } from "@/lib";
 import inspectUrl from "@/assets/mascot/inspect.png";
 
@@ -133,7 +133,20 @@ export function Preview({ source }: PreviewProps) {
     };
   }, []);
 
-  const html = useMemo(() => renderMarkdown(source, theme), [source, theme, ready]);
+  const [html, setHtml] = useState("");
+
+  // renderMarkdown is async (lazy-loads shiki themes + langs on demand).
+  // Cancelled flag guards against stale renders on rapid file/theme switches.
+  useEffect(() => {
+    if (!ready) return;
+    let cancelled = false;
+    void renderMarkdown(source, theme).then((h) => {
+      if (!cancelled) setHtml(h);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [source, theme, ready]);
 
   // Imperatively set innerHTML — React's dangerouslySetInnerHTML re-applies the
   // string on each parent re-render even when the value is unchanged, which

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -8,27 +8,19 @@ function mermaidId(): string {
   return `mdv-mermaid-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-// shiki lazy-loads grammars; registering all here for eager load.
+// allowed langs — shiki chunks load on first use via ensureLangsLoaded.
 const LANGS = [
-  // existing
   "markdown", "ts", "tsx", "js", "jsx", "json", "rust", "bash", "css", "html", "python", "go",
-  // systems / compiled
   "c", "cpp", "csharp", "objective-c",
-  // jvm / .net
   "java", "kotlin", "scala", "groovy",
-  // mobile / swift
   "swift",
-  // scripting
   "ruby", "php", "lua", "perl", "r", "elixir", "haskell",
-  // data / config
   "sql", "yaml", "toml", "xml", "ini",
-  // shell / devops
   "shellscript", "powershell", "dockerfile", "makefile", "nginx",
-  // diff / vcs
   "diff", "git-commit",
-  // misc commonly-pasted
   "graphql", "protobuf", "regex", "vim", "jsonc",
-];
+] as const;
+
 const THEMES = {
   latte: "catppuccin-latte",
   frappe: "catppuccin-frappe",
@@ -40,15 +32,16 @@ const THEMES = {
   ayu: "ayu-dark",
 } as const;
 
-let highlighterPromise: Promise<Highlighter> | null = null;
 let highlighter: Highlighter | null = null;
+let highlighterPromise: Promise<Highlighter> | null = null;
+const loadedLangs = new Set<string>();
+const loadedThemes = new Set<string>();
+// read synchronously inside md.highlight; updated before md.render in renderMarkdown.
+let activeShikiTheme: string = THEMES.latte;
 
 function getHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({
-      themes: Object.values(THEMES),
-      langs: LANGS,
-    })
+    highlighterPromise = createHighlighter({ themes: [], langs: [] })
       .then((h) => {
         highlighter = h;
         return h;
@@ -62,9 +55,32 @@ function getHighlighter(): Promise<Highlighter> {
   return highlighterPromise;
 }
 
-void getHighlighter().catch(() => {
-  // already logged in getHighlighter
-});
+const FENCE_RE = /^[ \t]*```([a-zA-Z0-9_+\-]+)/gm;
+function extractLangs(src: string): string[] {
+  const found = new Set<string>();
+  FENCE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = FENCE_RE.exec(src)) !== null) {
+    const lang = m[1];
+    if ((LANGS as readonly string[]).includes(lang)) found.add(lang);
+  }
+  return [...found];
+}
+
+async function ensureThemeLoaded(h: Highlighter, shikiTheme: string): Promise<void> {
+  if (loadedThemes.has(shikiTheme)) return;
+  await h.loadTheme(shikiTheme as Parameters<Highlighter["loadTheme"]>[0]);
+  loadedThemes.add(shikiTheme);
+}
+
+async function ensureLangsLoaded(h: Highlighter, langs: string[]): Promise<void> {
+  const toLoad = langs.filter((l) => !loadedLangs.has(l));
+  if (toLoad.length === 0) return;
+  await Promise.all(
+    toLoad.map((l) => h.loadLanguage(l as Parameters<Highlighter["loadLanguage"]>[0])),
+  );
+  toLoad.forEach((l) => loadedLangs.add(l));
+}
 
 const md = new MarkdownIt({
   html: false,
@@ -87,9 +103,7 @@ const md = new MarkdownIt({
     try {
       return highlighter.codeToHtml(code, {
         lang: language,
-        // pass all themes so every variant gets a css-var; defaultColor:false uses them.
-        themes: THEMES,
-        defaultColor: false,
+        theme: activeShikiTheme,
       });
     } catch {
       return "";
@@ -103,6 +117,11 @@ export async function ensureMarkdownReady(): Promise<void> {
   await getHighlighter();
 }
 
-export function renderMarkdown(src: string, _theme: Theme): string {
+export async function renderMarkdown(src: string, theme: Theme): Promise<string> {
+  const h = await getHighlighter();
+  const shikiTheme = THEMES[theme];
+  await ensureThemeLoaded(h, shikiTheme);
+  await ensureLangsLoaded(h, extractLangs(src));
+  activeShikiTheme = shikiTheme;
   return md.render(src);
 }

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -1,6 +1,7 @@
 import { tempDir } from "@tauri-apps/api/path";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { basename, writeMarkdown } from "./files";
+import { renderMarkdown } from "./markdown";
 
 // Tauri 2's WKWebView no-ops window.print(). We clone the rendered preview
 // article + wrap in a standalone html doc, write to OS temp, open in default
@@ -81,14 +82,8 @@ const PRINT_STYLES = `
   img { max-width: 100%; height: auto; border-radius: 6px; break-inside: avoid; }
   pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; }
   pre.shiki, pre.shiki * { font-family: inherit; }
-  /* shiki spans carry --shiki-{theme} vars inline; pick latte for print. */
-  .shiki, .shiki span {
-    background-color: transparent !important;
-    color: var(--shiki-latte) !important;
-    font-style: var(--shiki-latte-font-style, inherit) !important;
-    font-weight: var(--shiki-latte-font-weight, inherit) !important;
-    text-decoration: var(--shiki-latte-text-decoration, inherit) !important;
-  }
+  /* shiki spans carry inline color from the latte render — strip backgrounds for clean print */
+  .shiki, .shiki span { background-color: transparent !important; }
   blockquote {
     border-left: 3px solid var(--paccent);
     padding-left: 16px;
@@ -140,13 +135,14 @@ export async function exportPreviewToPdf({ source, activePath }: ExportOpts): Pr
   if (!source.trim()) {
     throw new PdfExportError("empty", "nothing to export. open or write some markdown first.");
   }
-  const article = document.querySelector<HTMLElement>(".mdv-prose");
-  if (!article) {
-    throw new PdfExportError("no-preview", "preview isn't rendered yet. try again in a moment.");
-  }
 
   const fileName = activePath ? basename(activePath) : undefined;
   const title = fileName ?? "marka.md export";
+
+  // Always render with latte for PDF — guarantees light, readable colors on
+  // white paper regardless of the user's current app theme. Lazy-loads the
+  // latte shiki theme on first non-latte export (~150-300ms one-time tax).
+  const latteHtml = await renderMarkdown(source, "latte");
 
   const html = `<!doctype html>
 <html lang="en">
@@ -158,7 +154,7 @@ export async function exportPreviewToPdf({ source, activePath }: ExportOpts): Pr
 </head>
 <body>
   <main class="doc">
-    ${article.outerHTML}
+    <article class="mdv-prose" data-theme="latte">${latteHtml}</article>
   </main>
   <script>
     window.addEventListener("load", () => {

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -143,74 +143,10 @@
   opacity: 1;
 }
 
-/* shiki dual-theme: spans carry --shiki-{theme} vars; pick by data-theme */
+/* shiki single-theme: inline span styles drive code colors */
 .mdv-prose .shiki,
 .mdv-prose .shiki span {
   background-color: transparent !important;
-}
-
-.mdv-prose[data-theme="latte"] .shiki,
-.mdv-prose[data-theme="latte"] .shiki span {
-  color: var(--shiki-latte) !important;
-  font-style: var(--shiki-latte-font-style, inherit) !important;
-  font-weight: var(--shiki-latte-font-weight, inherit) !important;
-  text-decoration: var(--shiki-latte-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="frappe"] .shiki,
-.mdv-prose[data-theme="frappe"] .shiki span {
-  color: var(--shiki-frappe) !important;
-  font-style: var(--shiki-frappe-font-style, inherit) !important;
-  font-weight: var(--shiki-frappe-font-weight, inherit) !important;
-  text-decoration: var(--shiki-frappe-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="macchiato"] .shiki,
-.mdv-prose[data-theme="macchiato"] .shiki span {
-  color: var(--shiki-macchiato) !important;
-  font-style: var(--shiki-macchiato-font-style, inherit) !important;
-  font-weight: var(--shiki-macchiato-font-weight, inherit) !important;
-  text-decoration: var(--shiki-macchiato-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="mocha"] .shiki,
-.mdv-prose[data-theme="mocha"] .shiki span {
-  color: var(--shiki-mocha) !important;
-  font-style: var(--shiki-mocha-font-style, inherit) !important;
-  font-weight: var(--shiki-mocha-font-weight, inherit) !important;
-  text-decoration: var(--shiki-mocha-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="matcha"] .shiki,
-.mdv-prose[data-theme="matcha"] .shiki span {
-  color: var(--shiki-matcha) !important;
-  font-style: var(--shiki-matcha-font-style, inherit) !important;
-  font-weight: var(--shiki-matcha-font-weight, inherit) !important;
-  text-decoration: var(--shiki-matcha-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="kanagawa"] .shiki,
-.mdv-prose[data-theme="kanagawa"] .shiki span {
-  color: var(--shiki-kanagawa) !important;
-  font-style: var(--shiki-kanagawa-font-style, inherit) !important;
-  font-weight: var(--shiki-kanagawa-font-weight, inherit) !important;
-  text-decoration: var(--shiki-kanagawa-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="rose-pine"] .shiki,
-.mdv-prose[data-theme="rose-pine"] .shiki span {
-  color: var(--shiki-rose-pine) !important;
-  font-style: var(--shiki-rose-pine-font-style, inherit) !important;
-  font-weight: var(--shiki-rose-pine-font-weight, inherit) !important;
-  text-decoration: var(--shiki-rose-pine-text-decoration, inherit) !important;
-}
-
-.mdv-prose[data-theme="ayu"] .shiki,
-.mdv-prose[data-theme="ayu"] .shiki span {
-  color: var(--shiki-ayu) !important;
-  font-style: var(--shiki-ayu-font-style, inherit) !important;
-  font-weight: var(--shiki-ayu-font-weight, inherit) !important;
-  text-decoration: var(--shiki-ayu-text-decoration, inherit) !important;
 }
 
 /* mermaid diagram container */


### PR DESCRIPTION
## Summary

Lazy-load shiki themes + languages on demand instead of eager-loading all 9 themes × 36 grammars at boot. Measured on macOS, fresh launch on demo file, 15s settle:

| metric | v1.3.8 | v1.4.0 | Δ |
|---|---:|---:|---:|
| WebContent RSS | 502 MB | 241 MB | **−261 MB (−52%)** |
| Total RSS | 670 MB | 404 MB | −266 MB (−40%) |

Motivated by sg130118's 5★ alternativeto.net review (only criticism: "RAM usage on the higher side").

## Changes

- `src/lib/markdown.ts` — empty highlighter init, `ensureThemeLoaded` + `ensureLangsLoaded` helpers, async `renderMarkdown`, single-theme `codeToHtml`
- `src/components/editor/preview.tsx` — `useMemo` → `useState`+`useEffect` for async render with cancellation flag (race protection)
- `src/styles/editor/prose.css` — dropped 8 `--shiki-{theme}` rule blocks; inline single-theme styles replace them
- `src/lib/pdf-export.ts` — fresh latte render for PDFs (guarantees light, readable colors on white paper regardless of active theme)

## Behavior changes (intentional)

- Theme switch is now a ~200-400ms re-render on first use (was instant CSS-var swap). Cached after first switch.
- PDF export gains ~150-300ms one-time tax on first export from non-latte theme.

## Test plan

- [x] type-check + production build clean
- [x] dev: demo renders, all langs highlight, theme cycle works, mermaid survives ⌘S
- [x] release build: RAM measured at -52% WebContent vs v1.3.8
- [ ] CI tri-platform builds (auto)
- [ ] Auto-update rolls to existing installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)