### PR TITLE
v1.4.1 — mark/strike, vim pill, editor-only mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "codemirror": "^6.0.2",
         "lucide-react": "^1.14.0",
         "markdown-it": "^14.1.1",
+        "markdown-it-mark": "^4.0.0",
         "markdown-it-task-lists": "^2.1.1",
         "mermaid": "^11.15.0",
         "react": "^19.1.0",
@@ -35,8 +36,8 @@
         "@types/node": "^25.7.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
-        "@vitejs/plugin-react": "^4.6.0",
-        "typescript": "~5.8.3",
+        "@vitejs/plugin-react": "^5.2.0",
+        "typescript": "~5.9.3",
         "vite": "^7.0.4",
       },
     },
@@ -198,7 +199,7 @@
 
     "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
 
@@ -400,7 +401,7 @@
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -566,6 +567,8 @@
 
     "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
+    "markdown-it-mark": ["markdown-it-mark@4.0.0", "", {}, "sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg=="],
+
     "markdown-it-task-lists": ["markdown-it-task-lists@2.1.1", "", {}, "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="],
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
@@ -618,7 +621,7 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
-    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -660,7 +663,7 @@
 
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "codemirror": "^6.0.2",
     "lucide-react": "^1.14.0",
     "markdown-it": "^14.1.1",
+    "markdown-it-mark": "^4.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "mermaid": "^11.15.0",
     "react": "^19.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.4.0"
+version = "1.4.1"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -155,8 +155,23 @@ export function App() {
   }, []);
 
   const [readingMode, setReadingMode] = useState(false);
-  const toggleReadingMode = useCallback(() => setReadingMode((v) => !v), []);
+  const [editorOnly, setEditorOnly] = useState(false);
+  // reading + editor-only are mutually exclusive view modes
+  const toggleReadingMode = useCallback(() => {
+    setReadingMode((v) => {
+      const next = !v;
+      if (next) setEditorOnly(false);
+      return next;
+    });
+  }, []);
   const exitReadingMode = useCallback(() => setReadingMode(false), []);
+  const toggleEditorOnly = useCallback(() => {
+    setEditorOnly((v) => {
+      const next = !v;
+      if (next) setReadingMode(false);
+      return next;
+    });
+  }, []);
 
   // ⌘F only bound while reading — CM owns it in editor mode.
   const [findOpen, setFindOpen] = useState(false);
@@ -431,6 +446,10 @@ export function App() {
         e.preventDefault();
         toggleReadingMode();
       },
+      "mod+shift+.": (e: KeyboardEvent) => {
+        e.preventDefault();
+        toggleEditorOnly();
+      },
       escape: (e: KeyboardEvent) => {
         if (readingMode) {
           e.preventDefault();
@@ -464,6 +483,7 @@ export function App() {
       readingMode,
       toggleReadingMode,
       exitReadingMode,
+      toggleEditorOnly,
     ],
   );
   useShortcuts(shortcuts);
@@ -495,6 +515,8 @@ export function App() {
         hasActivePath: activePath != null,
         sidebarOpen,
         readingMode,
+        editorOnly,
+        toggleEditorOnly,
       }),
     [
       handleNewFile,
@@ -583,10 +605,16 @@ export function App() {
               onCancelNew={() => setNewEntry(null)}
               treeVersion={treeVersion}
             />
-            <Splitter
-              left={<Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} />}
-              right={<Preview source={debouncedPreview} />}
-            />
+            {editorOnly ? (
+              <div className="mdv-shell__editor-solo">
+                <Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} />
+              </div>
+            ) : (
+              <Splitter
+                left={<Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} />}
+                right={<Preview source={debouncedPreview} />}
+              />
+            )}
           </>
         )}
       </main>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Breadcrumb, StatusBar, TitleBar } from "@/components/chrome";
+import { Breadcrumb, StatusBar, TitleBar, type VimMode } from "@/components/chrome";
 import { Editor, Preview, ReadingFind, Splitter } from "@/components/editor";
 import { ContextMenu, Sidebar, type ContextMenuItem } from "@/components/files";
 import { AboutOverlay, CommandPalette, DropOverlay, HelpOverlay, Toast, WelcomeOverlay } from "@/components/overlays";
@@ -124,6 +124,7 @@ export function App() {
   } = useUpdateFlow({ onError: setLoadError });
 
   const [vimOn, setVimOn] = usePersistedState<boolean>(STORAGE_KEYS.vimMode, false);
+  const [vimMode, setVimMode] = useState<VimMode | null>(null);
   const [dragActive, setDragActive] = useState(false);
 
   const handleToggleSidebar = useCallback(() => {
@@ -583,7 +584,7 @@ export function App() {
               treeVersion={treeVersion}
             />
             <Splitter
-              left={<Editor value={source} onChange={setSource} vimOn={vimOn} />}
+              left={<Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} />}
               right={<Preview source={debouncedPreview} />}
             />
           </>
@@ -715,6 +716,7 @@ export function App() {
         minutes={minutes}
         docTokens={docTokens}
         onShowHelp={() => setHelpOpen(true)}
+        vimMode={readingMode ? null : vimMode}
       />
     </div>
   );

--- a/src/components/chrome/index.ts
+++ b/src/components/chrome/index.ts
@@ -1,4 +1,4 @@
 export { Logo } from "./logo";
 export { TitleBar } from "./title-bar";
 export { Breadcrumb, type SaveStatus } from "./breadcrumb";
-export { StatusBar } from "./status-bar";
+export { StatusBar, type VimMode } from "./status-bar";

--- a/src/components/chrome/status-bar.tsx
+++ b/src/components/chrome/status-bar.tsx
@@ -2,6 +2,8 @@ import { CircleHelp } from "lucide-react";
 import { Button, Icon } from "@/components/primitives";
 import { formatTokens, shortcutLabel, startWindowDrag } from "@/lib";
 
+export type VimMode = "normal" | "insert" | "visual" | "replace";
+
 type StatusBarProps = {
   fileName?: string;
   words: number;
@@ -9,7 +11,22 @@ type StatusBarProps = {
   /** rough token count of the currently-loaded buffer */
   docTokens: number;
   onShowHelp: () => void;
+  /** when set, renders a vim-mode pill at the bottom-left (#23) */
+  vimMode?: VimMode | null;
 };
+
+function vimModeLabel(mode: VimMode): string {
+  switch (mode) {
+    case "normal":
+      return "NORMAL";
+    case "insert":
+      return "INSERT";
+    case "visual":
+      return "VISUAL";
+    case "replace":
+      return "REPLACE";
+  }
+}
 
 export function StatusBar({
   fileName,
@@ -17,10 +34,14 @@ export function StatusBar({
   minutes,
   docTokens,
   onShowHelp,
+  vimMode,
 }: StatusBarProps) {
   return (
     <footer className="mdv-statusbar" data-tauri-drag-region onMouseDown={startWindowDrag}>
       <div className="mdv-statusbar__group" data-tauri-drag-region>
+        {vimMode ? (
+          <span className={`mdv-vim-pill mdv-vim-pill--${vimMode}`}>{vimModeLabel(vimMode)}</span>
+        ) : null}
         <span data-tauri-drag-region>{fileName ?? "untitled"}</span>
       </div>
       <div className="mdv-statusbar__group" data-tauri-drag-region>

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -30,6 +30,8 @@ type EditorProps = {
   onChange: (next: string) => void;
   /** opt-in vim keybindings (lazy-loaded on first true) */
   vimOn?: boolean;
+  /** fired when vim mode changes; null when vim is off (#23) */
+  onVimMode?: (mode: "normal" | "insert" | "visual" | "replace" | null) => void;
 };
 
 function buildTheme() {
@@ -84,7 +86,7 @@ function buildTheme() {
   );
 }
 
-export function Editor({ value, onChange, vimOn = false }: EditorProps) {
+export function Editor({ value, onChange, vimOn = false, onVimMode }: EditorProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
@@ -144,16 +146,29 @@ export function Editor({ value, onChange, vimOn = false }: EditorProps) {
   // vim mode toggle (#23). Lazy-loads @replit/codemirror-vim on first enable
   // so non-vim users don't pay the ~200KB cost. Persists across re-renders via
   // the Compartment.reconfigure effect — doc + history are preserved.
+  // Wires `vim-mode-change` signal from the legacy CM adapter through onVimMode.
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
     const compartment = vimCompartment.current;
     let cancelled = false;
+    let detach: (() => void) | undefined;
     if (vimOn) {
       void import("@replit/codemirror-vim")
-        .then(({ vim }) => {
+        .then(({ vim, getCM }) => {
           if (cancelled) return;
           view.dispatch({ effects: compartment.reconfigure(vim()) });
+          // attach mode-change listener via legacy CodeMirror adapter
+          const cm = getCM(view);
+          if (cm && onVimMode) {
+            onVimMode("normal"); // vim starts in normal mode
+            const handler = (e: { mode: string }) => {
+              const m = e.mode as "normal" | "insert" | "visual" | "replace";
+              onVimMode(m);
+            };
+            cm.on("vim-mode-change", handler);
+            detach = () => cm.off("vim-mode-change", handler);
+          }
         })
         .catch((err) => {
           if (cancelled) return;
@@ -161,11 +176,13 @@ export function Editor({ value, onChange, vimOn = false }: EditorProps) {
         });
     } else {
       view.dispatch({ effects: compartment.reconfigure([]) });
+      onVimMode?.(null);
     }
     return () => {
       cancelled = true;
+      detach?.();
     };
-  }, [vimOn]);
+  }, [vimOn, onVimMode]);
 
   return <div ref={hostRef} className="mdv-editor" />;
 }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -45,6 +45,7 @@ export type CommandActions = {
   save: () => void;
   toggleSidebar: () => void;
   toggleReading: () => void;
+  toggleEditorOnly: () => void;
   showHelp: () => void;
   showWelcome: () => void;
   showAbout: () => void;
@@ -59,6 +60,7 @@ export type CommandActions = {
   hasActivePath: boolean;
   sidebarOpen: boolean;
   readingMode: boolean;
+  editorOnly: boolean;
 };
 
 const THEME_COMMANDS: Array<{ mode: ThemeMode; label: string; hint: string; icon: LucideIcon }> = [
@@ -168,6 +170,17 @@ export function buildCommands(actions: CommandActions): Command[] {
       icon: actions.readingMode ? Minimize2 : BookOpen,
       category: "view",
       action: actions.toggleReading,
+    },
+    {
+      id: "toggle-editor-only",
+      label: actions.editorOnly ? "exit editor-only" : "enter editor-only",
+      hint: actions.editorOnly
+        ? "back to split editor + preview"
+        : "hide the preview — focus on writing",
+      shortcut: "⌘⇧.",
+      icon: actions.editorOnly ? Minimize2 : FileText,
+      category: "view",
+      action: actions.toggleEditorOnly,
     },
     {
       id: "fullscreen",

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import mark from "markdown-it-mark";
 import taskLists from "markdown-it-task-lists";
 import { createHighlighter, type Highlighter } from "shiki";
 import type { Theme } from "./theme";
@@ -112,6 +113,7 @@ const md = new MarkdownIt({
 });
 
 md.use(taskLists, { enabled: false, label: true });
+md.use(mark);
 
 export async function ensureMarkdownReady(): Promise<void> {
   await getHighlighter();

--- a/src/styles/chrome/statusbar.css
+++ b/src/styles/chrome/statusbar.css
@@ -29,3 +29,37 @@
   background: transparent;
 }
 
+.mdv-vim-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  background: color-mix(in srgb, var(--muted) 18%, transparent);
+  color: var(--muted);
+  border: 1px solid color-mix(in srgb, var(--muted) 25%, transparent);
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.mdv-vim-pill--insert {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.mdv-vim-pill--visual {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.mdv-vim-pill--replace {
+  background: color-mix(in srgb, #e74c3c 18%, transparent);
+  color: #e74c3c;
+  border-color: color-mix(in srgb, #e74c3c 35%, transparent);
+}
+

--- a/src/styles/editor/panes.css
+++ b/src/styles/editor/panes.css
@@ -11,6 +11,13 @@
   min-width: 0;
 }
 
+/* editor-only mode (#28) — preview pane hidden, editor fills remaining width */
+.mdv-shell__editor-solo {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
 /* splitter */
 .mdv-splitter {
   display: grid;

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -238,6 +238,18 @@
 }
 
 .mdv-prose strong { font-weight: 600; }
+.mdv-prose s,
+.mdv-prose del {
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+  opacity: 0.7;
+}
+.mdv-prose mark {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: inherit;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
 .mdv-prose em { font-style: italic; }
 
 .mdv-prose img {

--- a/src/types/markdown-it-mark.d.ts
+++ b/src/types/markdown-it-mark.d.ts
@@ -1,0 +1,6 @@
+declare module "markdown-it-mark" {
+  import type { PluginSimple } from "markdown-it";
+
+  const plugin: PluginSimple;
+  export default plugin;
+}


### PR DESCRIPTION
## Summary

Three small wins addressing direct user feedback from @arijit4:

### Closes #29 — markdown rendering
- Added `markdown-it-mark` plugin → `==highlight==` now renders as `<mark>`
- Verified `~~strikethrough~~` works (markdown-it built-in)
- Added explicit CSS for `s/del` (line-through, 0.7 opacity) and `mark` (theme-accent background pill)

### Closes #23 — vim status-bar pill
- Bottom-left **NORMAL / INSERT / VISUAL / REPLACE** indicator appears when vim mode is on
- Wired via `@replit/codemirror-vim`'s `vim-mode-change` signal
- Hidden in reading mode (no editor visible)
- Color-coded: muted (normal), accent (insert/visual), red-ish (replace)

### Closes #28 — toggle live preview
- `⌘⇧.` toggles editor-only mode (mirror of `⌘.` reading mode)
- Mutually exclusive with reading mode (toggling one clears the other)
- Available in command palette: "enter editor-only"

## Test plan

- [x] type-check + build clean
- [x] manual walkthrough approved
- [ ] CI tri-platform build
- [ ] Auto-update rolls to ~550 installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)