### PR TITLE
v1.4.2 — fix mod+shift+. shortcut on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.4.1"
+version = "1.4.2"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/hooks/use-shortcuts.ts
+++ b/src/hooks/use-shortcuts.ts
@@ -5,6 +5,23 @@ export type ShortcutHandler = (event: KeyboardEvent) => void;
 const IS_MAC =
   typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
+// Maps a literal shifted-symbol char in a shortcut (e.g. "." in "mod+shift+.")
+// to its physical KeyboardEvent.code. Needed because shift+. produces e.key=">"
+// on US layouts — falling back to e.code makes the matcher layout-independent.
+const SHIFTED_KEY_CODES: Record<string, string> = {
+  ".": "Period",
+  ",": "Comma",
+  "/": "Slash",
+  ";": "Semicolon",
+  "'": "Quote",
+  "[": "BracketLeft",
+  "]": "BracketRight",
+  "\\": "Backslash",
+  "`": "Backquote",
+  "-": "Minus",
+  "=": "Equal",
+};
+
 /**
  * Map keys like "mod+b" / "mod+shift+o" / "mod+ctrl+f" / "esc" to handlers.
  *
@@ -40,8 +57,11 @@ export function useShortcuts(map: Record<string, ShortcutHandler>): void {
         const needsShift = parts.includes("shift");
         const needsAlt = parts.includes("alt") || parts.includes("option");
         const wantKey = parts[parts.length - 1];
+        const wantCode = SHIFTED_KEY_CODES[wantKey];
 
-        if (key !== wantKey) continue;
+        // Match against e.key first; fall back to e.code for shifted symbols
+        // (shift+. produces e.key=">", but e.code stays "Period" regardless).
+        if (key !== wantKey && !(wantCode && e.code === wantCode)) continue;
 
         // platform-aware modifier matching:
         //   "mod+x"        → primary modifier only; reject any extra ctrl on mac


### PR DESCRIPTION
## Summary

Closes #32. Fixes `mod+shift+.` (editor-only toggle) silently dropping on Windows (and would on any layout where `shift+.` produces a different `e.key`).

## Root cause

`use-shortcuts.ts:34` matched `e.key.toLowerCase() === wantKey`. On US layouts, `Shift+.` produces `e.key === ">"`, so the literal `"."` in shortcut definitions never matched when shift was held. macOS happened to dodge it because users typically discover the command via the palette, not the shortcut.

## Fix

Added `SHIFTED_KEY_CODES` map (`.` → `"Period"`, `,` → `"Comma"`, etc) and an `e.code` fallback: if `e.key` doesn't match the literal shortcut char, also try matching against the physical key code. Layout-independent + future-proofs other shifted-symbol shortcuts.

## Test plan

- [x] type-check + build clean
- [x] root-cause traced
- [ ] CI tri-platform build (auto)
- [ ] arijit verifies on Windows after auto-update

🤖 Generated with [Claude Code](https://claude.com/claude-code)