### PR TITLE
fix(export): render Mermaid diagrams in PDF export

### DIFF
--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -1,63 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ensureMarkdownReady, renderMarkdown, useTheme } from "@/lib";
 import inspectUrl from "@/assets/mascot/inspect.png";
-
-let mermaidLib: typeof import("mermaid")["default"] | null = null;
-let mermaidLoading: Promise<typeof import("mermaid")["default"]> | null = null;
-let mermaidInitializedTheme: "default" | "dark" | null = null;
-
-async function getMermaid(themeName: "default" | "dark") {
-  if (mermaidLib) return mermaidLib;
-  if (!mermaidLoading) {
-    mermaidLoading = import("mermaid").then((mod) => {
-      mod.default.initialize({
-        startOnLoad: false,
-        theme: themeName,
-        securityLevel: "strict",
-        fontFamily: "JetBrains Mono, ui-monospace, monospace",
-      });
-      mermaidInitializedTheme = themeName;
-      mermaidLib = mod.default;
-      return mod.default;
-    });
-  }
-  return mermaidLoading;
-}
-
-async function renderMermaidBlocks(root: HTMLElement, theme: "default" | "dark") {
-  const blocks = Array.from(root.querySelectorAll<HTMLPreElement>("pre.mdv-mermaid:not(.is-rendered)"));
-  if (blocks.length === 0) return;
-  const mermaid = await getMermaid(theme);
-  // only re-initialize when theme actually changed; avoids id-registry churn + flicker
-  if (mermaidInitializedTheme !== theme) {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme,
-      securityLevel: "strict",
-      fontFamily: "JetBrains Mono, ui-monospace, monospace",
-    });
-    mermaidInitializedTheme = theme;
-  }
-
-  for (const pre of blocks) {
-    const code = pre.querySelector("code")?.textContent ?? "";
-    const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    try {
-      const { svg } = await mermaid.render(`${id}-svg`, code);
-      pre.innerHTML = svg;
-      pre.classList.add("is-rendered");
-    } catch (err) {
-      console.error("marka.md: mermaid render failed", err);
-      // safe fallback — build with textContent, never innerHTML on user input
-      pre.replaceChildren();
-      const codeEl = document.createElement("code");
-      codeEl.className = "mdv-mermaid__error";
-      codeEl.textContent = code;
-      pre.appendChild(codeEl);
-      pre.classList.add("is-rendered", "is-error");
-    }
-  }
-}
+import { renderMermaidBlocks } from "@/lib/mermaid";
 
 type PreviewProps = {
   source: string;

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -1,0 +1,64 @@
+let mermaidLib: typeof import("mermaid")["default"] | null = null;
+let mermaidLoading: Promise<typeof import("mermaid")["default"]> | null = null;
+let mermaidInitializedTheme: "default" | "dark" | null = null;
+
+async function getMermaid(themeName: "default" | "dark") {
+  if (mermaidLib) return mermaidLib;
+  if (!mermaidLoading) {
+    mermaidLoading = import("mermaid").then((mod) => {
+      mod.default.initialize({
+        startOnLoad: false,
+        theme: themeName,
+        securityLevel: "strict",
+        fontFamily: "JetBrains Mono, ui-monospace, monospace",
+      });
+      mermaidInitializedTheme = themeName;
+      mermaidLib = mod.default;
+      return mod.default;
+    });
+  }
+  return mermaidLoading;
+}
+
+export async function renderMermaidBlocks(root: ParentNode, theme: "default" | "dark"): Promise<void> {
+  const blocks = Array.from(root.querySelectorAll<HTMLPreElement>("pre.mdv-mermaid:not(.is-rendered)"));
+  if (blocks.length === 0) return;
+  const mermaid = await getMermaid(theme);
+  if (mermaidInitializedTheme !== theme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme,
+      securityLevel: "strict",
+      fontFamily: "JetBrains Mono, ui-monospace, monospace",
+    });
+    mermaidInitializedTheme = theme;
+  }
+
+  for (const pre of blocks) {
+    const code = pre.querySelector("code")?.textContent ?? "";
+    const id = pre.id || `mdv-mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    try {
+      const { svg } = await mermaid.render(`${id}-svg`, code);
+      pre.innerHTML = svg;
+      pre.classList.add("is-rendered");
+    } catch (err) {
+      console.error("marka.md: mermaid render failed", err);
+      pre.replaceChildren();
+      const codeEl = document.createElement("code");
+      codeEl.className = "mdv-mermaid__error";
+      codeEl.textContent = code;
+      pre.appendChild(codeEl);
+      pre.classList.add("is-rendered", "is-error");
+    }
+  }
+}
+
+export async function renderMermaidInHtml(html: string, theme: "default" | "dark"): Promise<string> {
+  if (!html.includes("mdv-mermaid")) return html;
+  if (typeof document === "undefined") return html;
+
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  await renderMermaidBlocks(template.content, theme);
+  return template.innerHTML;
+}

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -2,6 +2,7 @@ import { tempDir } from "@tauri-apps/api/path";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { basename, writeMarkdown } from "./files";
 import { renderMarkdown } from "./markdown";
+import { renderMermaidInHtml } from "./mermaid";
 
 // Tauri 2's WKWebView no-ops window.print(). We render a standalone html doc,
 // write to OS temp, then open in the default browser. Browser auto-prints on
@@ -152,7 +153,8 @@ export async function exportPreviewToPdf({ source, activePath }: ExportOpts): Pr
   // Always render with latte for PDF — guarantees light, readable colors on
   // white paper regardless of the user's current app theme. Lazy-loads the
   // latte shiki theme on first non-latte export (~150-300ms one-time tax).
-  const latteHtml = await renderMarkdown(source, "latte");
+  const renderedHtml = await renderMarkdown(source, "latte");
+  const latteHtml = await renderMermaidInHtml(renderedHtml, "default");
 
   const html = `<!doctype html>
 <html lang="en">

--- a/tests/pdf-export.test.ts
+++ b/tests/pdf-export.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { PRINT_STYLES } from "../src/lib/pdf-export";
+import { renderMermaidInHtml } from "../src/lib/mermaid";
 
 test("suppresses browser print header and footer space", () => {
   expect(PRINT_STYLES).toContain("@page { margin: 0; size: auto; }");
@@ -16,4 +17,11 @@ test("clones document padding across printed page fragments", () => {
   expect(PRINT_STYLES).toContain("-webkit-box-decoration-break: clone;");
   expect(PRINT_STYLES).toContain("box-decoration-break: clone;");
   expect(PRINT_STYLES).toContain("body { margin: 0; padding: 0; }");
+});
+
+test("keeps mermaid html stable when no browser document is available", async () => {
+  const html = '<pre class="mdv-mermaid" id="flow"><code>flowchart TD\\nA-->B</code></pre>';
+  const rendered = await renderMermaidInHtml(html, "default");
+
+  expect(rendered).toBe(html);
 });


### PR DESCRIPTION
## Summary

- Share the Mermaid renderer between live preview and PDF export
- Render Mermaid blocks to SVG before writing print HTML
- Keep the PDF export helper safe in non-browser test environments

Fixes #36.

## Verification

- `bun test tests/pdf-export.test.ts`
- `bun run build`
- Manual local export test with `mermaid-export-test.md`: diagram rendered in print/PDF instead of Mermaid source text