### PR TITLE
Fix macOS file open and polish themes/code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <img src="https://img.shields.io/badge/notarized-Apple%20Developer-orange?style=flat-square" alt="notarized" />
 </p>
 
-a cross-platform (**macOS · Windows · Linux**) markdown editor specialized for **ai context management**. live editor on the left (codemirror 6), rendered preview on the right (markdown-it + shiki + mermaid), and a context tray for staging multiple notes into one AI-ready bundle. minimal chrome, 8 themes (catppuccin + matcha + kanagawa + rose pine + ayu), orange octopus mascot. ~10 mb bundle, ~240 mb resident — lean for a tauri app.
+a cross-platform (**macOS · Windows · Linux**) markdown editor specialized for **ai context management**. live editor on the left (codemirror 6), rendered preview on the right (markdown-it + shiki + mermaid), and a context tray for staging multiple notes into one AI-ready bundle. minimal chrome, grouped themes (neutral + catppuccin + ai-inspired + crafted), orange octopus mascot. ~10 mb bundle, ~240 mb resident — lean for a tauri app.
 
 > built around one loop: **collect notes → write → share with ai**. nothing leaves your machine until you copy.
 
@@ -27,7 +27,7 @@ works with claude, chatgpt, gemini, your local agent — anywhere that reads pla
 ## features
 
 - **live preview** — ~50 ms render, shiki code highlighting (36 langs, lazy-loaded), mermaid diagrams
-- **8 themes** — catppuccin family (latte / frappé / macchiato / mocha), matcha, kanagawa, rose pine, ayu + system auto-switch · hover-to-preview in menu
+- **grouped themes** — mono, mono dark, catppuccin family, crafted palettes, plus AI-inspired Claude / Codex / Gemini / Cursor themes · animated sections + hover-to-preview
 - **reading mode** — ⌘. distraction-free preview with iA-style typography
 - **editor-only mode** — ⌘⇧. hide the preview when you want to focus on writing
 - **vim mode** — opt-in via theme menu · NORMAL/INSERT/VISUAL/REPLACE pill in the status bar
@@ -149,6 +149,9 @@ per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 - **context tray** — multi-file bundling, ⌘-click to stage, token estimates, copy as one prompt blob
 - **what's new toast** — first launch after update now points users straight to the changelog
 - **pdf export polish** — cleaner document margins, no browser-added date/time/path headers, and rendered mermaid diagrams
+- **theme polish** — mono / mono dark, animated grouped theme menu, and AI-inspired Claude / Codex / Gemini / Cursor palettes
+- **code block wrapping** — long rendered code lines wrap in preview and PDF export
+- **macOS file handling** — default-handler launches open the selected markdown file reliably
 
 **next**:
 - native/silent PDF generation, so export does not depend on the browser print dialog

--- a/docs/release-notes/v1.5.2.md
+++ b/docs/release-notes/v1.5.2.md
@@ -1,0 +1,14 @@
+# v1.5.2
+
+v1.5.2 is a polish release for opening files, themes, and rendered code blocks.
+
+## fixed
+
+- macOS default-handler launches now open the file you double-clicked, not the previous document from session restore.
+- rendered code blocks now wrap long lines in preview and PDF export.
+
+## improved
+
+- added mono and mono dark themes for distraction-free black/white writing.
+- grouped the theme menu into animated sections: neutral, catppuccin, ai, and crafted.
+- added AI-inspired palettes for Claude, Codex, Gemini, and Cursor.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.5.1"
+version = "1.5.2"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(target_os = "macos")]
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
 
+use std::sync::Mutex;
+use tauri::State;
+
 // `Manager` powers `_app.get_webview_window` in the macOS setup block,
 // `Emitter` powers the file-open event below, and `RunEvent::Opened` is a
 // macOS-only enum variant (Finder "Open With" file association). Gating the
@@ -9,14 +12,27 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectStat
 #[cfg(target_os = "macos")]
 use tauri::{Emitter, Manager, RunEvent};
 
+struct PendingOpenFiles(Mutex<Vec<String>>);
+
+#[tauri::command]
+fn take_pending_open_files(state: State<'_, PendingOpenFiles>) -> Vec<String> {
+    let mut pending = state
+        .0
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::take(&mut *pending)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
+        .manage(PendingOpenFiles(Mutex::new(Vec::new())))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .invoke_handler(tauri::generate_handler![take_pending_open_files])
         .setup(|_app| {
             #[cfg(target_os = "macos")]
             {
@@ -44,6 +60,13 @@ pub fn run() {
             for url in urls {
                 if let Ok(path) = url.to_file_path() {
                     let path_str = path.to_string_lossy().to_string();
+                    if let Some(state) = _app_handle.try_state::<PendingOpenFiles>() {
+                        let mut pending = state
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        pending.push(path_str.clone());
+                    }
                     if let Err(err) = _app_handle.emit("marka:open-file", path_str.clone()) {
                         eprintln!("marka.md: failed to emit open-file event: {err:?}");
                     } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -19,6 +19,7 @@ import {
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 import {
   basename,
@@ -379,6 +380,14 @@ export function App() {
       }
     }).then((un) => {
       unlisten = un;
+      void invoke<string[]>("take_pending_open_files")
+        .then((paths) => {
+          const latest = paths[paths.length - 1];
+          if (latest) void loadFile(latest);
+        })
+        .catch((err) => {
+          console.warn("marka.md: pending open-file check failed", err);
+        });
     });
     return () => {
       unlisten?.();

--- a/src/components/chrome/title-bar.tsx
+++ b/src/components/chrome/title-bar.tsx
@@ -2,6 +2,8 @@ import { useRef, useState } from "react";
 import {
   BookOpen,
   Check,
+  ChevronRight,
+  Circle,
   Cloud,
   Coffee,
   Copy,
@@ -18,7 +20,7 @@ import {
   Waves,
 } from "lucide-react";
 import { Button, Icon, Popover } from "@/components/primitives";
-import { getSystemTheme, previewTheme, shortcutLabel, startWindowDrag, useThemeMode, useTransparency, type Theme, type ThemeMode } from "@/lib";
+import { getSystemTheme, previewTheme, shortcutLabel, startWindowDrag, THEME_GROUPS, useThemeMode, useTransparency, type Theme, type ThemeMode } from "@/lib";
 
 type TitleBarProps = {
   fileName?: string;
@@ -33,19 +35,23 @@ type TitleBarProps = {
   onToggleVim?: () => void;
 };
 
-type ThemeChoice = { value: ThemeMode; label: string; icon: typeof Sun };
-
-const THEME_CHOICES: ThemeChoice[] = [
-  { value: "system", label: "system", icon: Monitor },
-  { value: "latte", label: "latte", icon: Sun },
-  { value: "matcha", label: "matcha", icon: Leaf },
-  { value: "frappe", label: "frappé", icon: Cloud },
-  { value: "macchiato", label: "macchiato", icon: Coffee },
-  { value: "mocha", label: "mocha", icon: Moon },
-  { value: "kanagawa", label: "kanagawa", icon: Waves },
-  { value: "rose-pine", label: "rose pine", icon: Flower2 },
-  { value: "ayu", label: "ayu", icon: Sunset },
-];
+const THEME_ICONS: Record<ThemeMode, typeof Sun> = {
+  system: Monitor,
+  latte: Sun,
+  mono: Circle,
+  "mono-dark": Circle,
+  matcha: Leaf,
+  frappe: Cloud,
+  macchiato: Coffee,
+  mocha: Moon,
+  kanagawa: Waves,
+  "rose-pine": Flower2,
+  ayu: Sunset,
+  claude: Sparkles,
+  codex: Terminal,
+  gemini: Sparkles,
+  cursor: Terminal,
+};
 
 export function TitleBar({
   vimOn = false,
@@ -62,6 +68,9 @@ export function TitleBar({
   const { mode, resolved, setMode } = useThemeMode();
   const { opacity, on: transparent, set: setTransparency } = useTransparency();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [openThemeGroups, setOpenThemeGroups] = useState<Set<string>>(
+    () => new Set(["neutral", "ai"]),
+  );
   const themeAnchorRef = useRef<HTMLDivElement>(null);
   const hoverTimer = useRef<number | null>(null);
   const resolveThemeForPreview = (value: ThemeMode): Theme =>
@@ -87,7 +96,18 @@ export function TitleBar({
   const ActiveIcon =
     mode === "system"
       ? Monitor
-      : (THEME_CHOICES.find((c) => c.value === resolved)?.icon ?? Coffee);
+      : THEME_ICONS[resolved];
+  const toggleThemeGroup = (label: string) => {
+    setOpenThemeGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  };
 
   return (
     <header className="mdv-titlebar" data-tauri-drag-region onMouseDown={startWindowDrag}>
@@ -158,37 +178,60 @@ export function TitleBar({
             anchorRef={themeAnchorRef}
           >
             <div className="mdv-menu" onMouseLeave={cancelPreview}>
-              <div className="mdv-menu__label">theme</div>
-              {THEME_CHOICES.map((c) => {
-                const active = mode === c.value;
+              {THEME_GROUPS.map((group) => {
+                const activeInGroup = group.choices.some((c) => c.value === mode);
+                const expanded = openThemeGroups.has(group.label) || activeInGroup;
                 return (
-                  <button
-                    key={c.value}
-                    type="button"
-                    className={`mdv-menu__item${active ? " is-active" : ""}`}
-                    onMouseEnter={() => previewOnHover(c.value)}
-                    onMouseLeave={cancelHoverTimer}
-                    onFocus={() => previewOnHover(c.value)}
-                    onBlur={cancelHoverTimer}
-                    onClick={() => {
-                      // click commits immediately + closes menu
-                      cancelPreview();
-                      setMode(c.value);
-                      setMenuOpen(false);
-                    }}
-                    role="menuitemradio"
-                    aria-checked={active}
+                  <section
+                    key={group.label}
+                    className={`mdv-menu__group${expanded ? " is-open" : ""}`}
                   >
-                    <span className="mdv-menu__item-icon">
-                      <Icon icon={c.icon} size={14} strokeWidth={1.5} />
-                    </span>
-                    <span className="mdv-menu__item-label">{c.label}</span>
-                    {active ? (
-                      <span className="mdv-menu__item-check">
-                        <Icon icon={Check} size={13} strokeWidth={2} />
-                      </span>
-                    ) : null}
-                  </button>
+                    <button
+                      type="button"
+                      className="mdv-menu__group-trigger"
+                      onClick={() => toggleThemeGroup(group.label)}
+                      aria-expanded={expanded}
+                    >
+                      <span>{group.label}</span>
+                      <Icon icon={ChevronRight} size={13} strokeWidth={1.7} />
+                    </button>
+                    <div className="mdv-menu__group-body">
+                      <div className="mdv-menu__group-inner">
+                        {group.choices.map((c) => {
+                          const active = mode === c.value;
+                          return (
+                            <button
+                              key={c.value}
+                              type="button"
+                              className={`mdv-menu__item${active ? " is-active" : ""}`}
+                              onMouseEnter={() => previewOnHover(c.value)}
+                              onMouseLeave={cancelHoverTimer}
+                              onFocus={() => previewOnHover(c.value)}
+                              onBlur={cancelHoverTimer}
+                              onClick={() => {
+                                // click commits immediately + closes menu
+                                cancelPreview();
+                                setMode(c.value);
+                                setMenuOpen(false);
+                              }}
+                              role="menuitemradio"
+                              aria-checked={active}
+                            >
+                              <span className="mdv-menu__item-icon">
+                                <Icon icon={THEME_ICONS[c.value]} size={14} strokeWidth={1.5} />
+                              </span>
+                              <span className="mdv-menu__item-label">{c.label}</span>
+                              {active ? (
+                                <span className="mdv-menu__item-check">
+                                  <Icon icon={Check} size={13} strokeWidth={2} />
+                                </span>
+                              ) : null}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </section>
                 );
               })}
               <div className="mdv-menu__divider" aria-hidden />

--- a/src/hooks/use-file-session.ts
+++ b/src/hooks/use-file-session.ts
@@ -66,6 +66,7 @@ export function useFileSession({ onLoadError }: UseFileSessionArgs = {}): UseFil
   );
   const [externalReloadToast, setExternalReloadToast] = useState(false);
   const [externalConflict, setExternalConflict] = useState<string | null>(null);
+  const loadSeq = useRef(0);
 
   const dismissExternalReload = useCallback(() => setExternalReloadToast(false), []);
 
@@ -77,7 +78,9 @@ export function useFileSession({ onLoadError }: UseFileSessionArgs = {}): UseFil
 
   const loadFile = useCallback(
     async (path: string) => {
+      const seq = ++loadSeq.current;
       const check = await validateMarkdownFile(path);
+      if (seq !== loadSeq.current) return;
       if (!check.ok) {
         onLoadError?.({ message: check.reason, path });
         console.warn("marka.md: refused to open", path, "·", check.reason);
@@ -85,6 +88,7 @@ export function useFileSession({ onLoadError }: UseFileSessionArgs = {}): UseFil
       }
       try {
         const content = await readMarkdown(path);
+        if (seq !== loadSeq.current) return;
         setSource(content);
         setSavedContent(content);
         setActivePath(path);

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
   BookOpen,
+  Circle,
   CircleHelp,
   Copy,
   FilePlus2,
@@ -24,7 +25,7 @@ import {
   Sun,
 } from "lucide-react";
 import { basename, dirname } from "./files";
-import { setThemeMode, setTransparency, type ThemeMode } from "./theme";
+import { setThemeMode, setTransparency, THEME_CHOICES, THEME_HINTS, type ThemeMode } from "./theme";
 
 export type CommandCategory = "recent" | "file" | "view" | "edit" | "share" | "theme" | "help";
 
@@ -67,14 +68,31 @@ export type CommandActions = {
   contextCount: number;
 };
 
-const THEME_COMMANDS: Array<{ mode: ThemeMode; label: string; hint: string; icon: LucideIcon }> = [
-  { mode: "system", label: "theme: system", hint: "follow macOS appearance", icon: Monitor },
-  { mode: "latte", label: "theme: latte", hint: "catppuccin light", icon: Sun },
-  { mode: "matcha", label: "theme: matcha", hint: "washi paper + kelly green", icon: Leaf },
-  { mode: "frappe", label: "theme: frappé", hint: "catppuccin mid-dark", icon: Moon },
-  { mode: "macchiato", label: "theme: macchiato", hint: "catppuccin deeper dark", icon: Moon },
-  { mode: "mocha", label: "theme: mocha", hint: "catppuccin deepest dark", icon: Moon },
-];
+const THEME_ICONS: Record<ThemeMode, LucideIcon> = {
+  system: Monitor,
+  latte: Sun,
+  mono: Circle,
+  "mono-dark": Circle,
+  matcha: Leaf,
+  frappe: Moon,
+  macchiato: Moon,
+  mocha: Moon,
+  kanagawa: Moon,
+  "rose-pine": Moon,
+  ayu: Moon,
+  claude: Sparkles,
+  codex: Moon,
+  gemini: Sparkles,
+  cursor: Circle,
+};
+
+const THEME_COMMANDS: Array<{ mode: ThemeMode; label: string; hint: string; icon: LucideIcon }> =
+  THEME_CHOICES.map((theme) => ({
+    mode: theme.value,
+    label: `theme: ${theme.label}`,
+    hint: THEME_HINTS[theme.value],
+    icon: THEME_ICONS[theme.value],
+  }));
 
 export const CATEGORY_ORDER: CommandCategory[] = [
   "recent",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,7 +7,12 @@ export {
   setTransparency,
   getSystemTheme,
   previewTheme,
+  THEME_CHOICES,
+  THEME_GROUPS,
+  THEME_HINTS,
   type Theme,
+  type ThemeChoice,
+  type ThemeGroup,
   type ThemeMode,
 } from "./theme";
 export { STORAGE_KEYS, type StorageKey } from "./storage";

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -24,6 +24,8 @@ const LANGS = [
 
 const THEMES = {
   latte: "catppuccin-latte",
+  mono: "github-light",
+  "mono-dark": "github-dark",
   frappe: "catppuccin-frappe",
   macchiato: "catppuccin-macchiato",
   mocha: "catppuccin-mocha",
@@ -31,6 +33,10 @@ const THEMES = {
   kanagawa: "kanagawa-wave",
   "rose-pine": "rose-pine",
   ayu: "ayu-dark",
+  claude: "vitesse-light",
+  codex: "github-dark",
+  gemini: "github-light",
+  cursor: "github-dark-dimmed",
 } as const;
 
 let highlighter: Highlighter | null = null;

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -84,6 +84,8 @@ export const PRINT_STYLES = `
     border-radius: 8px;
     padding: 14px 16px;
     overflow-x: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
     break-inside: avoid;
     page-break-inside: avoid;
   }
@@ -92,7 +94,7 @@ export const PRINT_STYLES = `
     page-break-inside: avoid;
   }
   img { max-width: 100%; height: auto; border-radius: 6px; break-inside: avoid; }
-  pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; }
+  pre code { background: transparent; padding: 0; font-size: inherit; border-radius: 0; white-space: inherit; }
   pre.shiki, pre.shiki * { font-family: inherit; }
   /* shiki spans carry inline color from the latte render — strip backgrounds for clean print */
   .shiki, .shiki span { background-color: transparent !important; }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -3,18 +3,28 @@ import { STORAGE_KEYS } from "./storage";
 
 export type Theme =
   | "latte"
+  | "mono"
+  | "mono-dark"
   | "frappe"
   | "macchiato"
   | "mocha"
   | "matcha"
   | "kanagawa"
   | "rose-pine"
-  | "ayu";
+  | "ayu"
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "cursor";
 export type ThemeMode = "system" | Theme;
+export type ThemeChoice = { value: ThemeMode; label: string };
+export type ThemeGroup = { label: string; choices: ThemeChoice[] };
 
 const VALID: ReadonlyArray<ThemeMode> = [
   "system",
   "latte",
+  "mono",
+  "mono-dark",
   "frappe",
   "macchiato",
   "mocha",
@@ -22,7 +32,72 @@ const VALID: ReadonlyArray<ThemeMode> = [
   "kanagawa",
   "rose-pine",
   "ayu",
+  "claude",
+  "codex",
+  "gemini",
+  "cursor",
 ];
+
+export const THEME_GROUPS: ThemeGroup[] = [
+  {
+    label: "neutral",
+    choices: [
+      { value: "system", label: "system" },
+      { value: "mono", label: "mono" },
+      { value: "mono-dark", label: "mono dark" },
+    ],
+  },
+  {
+    label: "catppuccin",
+    choices: [
+      { value: "latte", label: "latte" },
+      { value: "frappe", label: "frappé" },
+      { value: "macchiato", label: "macchiato" },
+      { value: "mocha", label: "mocha" },
+    ],
+  },
+  {
+    label: "ai",
+    choices: [
+      { value: "claude", label: "claude" },
+      { value: "codex", label: "codex" },
+      { value: "gemini", label: "gemini" },
+      { value: "cursor", label: "cursor" },
+    ],
+  },
+  {
+    label: "crafted",
+    choices: [
+      { value: "matcha", label: "matcha" },
+      { value: "kanagawa", label: "kanagawa" },
+      { value: "rose-pine", label: "rose pine" },
+      { value: "ayu", label: "ayu" },
+    ],
+  },
+];
+
+export const THEME_CHOICES: ThemeChoice[] = [];
+for (const group of THEME_GROUPS) {
+  THEME_CHOICES.push(...group.choices);
+}
+
+export const THEME_HINTS: Record<ThemeMode, string> = {
+  system: "follow macOS appearance",
+  latte: "catppuccin light",
+  mono: "plain black and white",
+  "mono-dark": "reverse black and white",
+  matcha: "washi paper + kelly green",
+  frappe: "catppuccin mid-dark",
+  macchiato: "catppuccin deeper dark",
+  mocha: "catppuccin deepest dark",
+  kanagawa: "ink-wash dark",
+  "rose-pine": "rose pine dark",
+  ayu: "ayu mirage dark",
+  claude: "warm parchment + terracotta",
+  codex: "openai black + green",
+  gemini: "blue and violet glow",
+  cursor: "warm editor neutrals",
+};
 
 const STORAGE_KEY = STORAGE_KEYS.themeMode;
 const MQ = "(prefers-color-scheme: dark)";

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -70,6 +70,8 @@
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   background: color-mix(in srgb, var(--bg-solid, var(--bg)) 80%, var(--muted) 12%);
   margin: 0;
 }
@@ -79,6 +81,7 @@
   border: 0;
   padding: 0;
   font-size: inherit;
+  white-space: inherit;
 }
 
 /* code block + copy button */
@@ -166,6 +169,7 @@
   font-size: 0.85em;
   color: var(--muted);
   white-space: pre;
+  overflow-wrap: normal;
 }
 
 .mdv-mermaid.is-rendered {

--- a/src/styles/shared/menu.css
+++ b/src/styles/shared/menu.css
@@ -73,6 +73,69 @@
   gap: 1px;
 }
 
+.mdv-menu__group {
+  display: flex;
+  flex-direction: column;
+}
+
+.mdv-menu__group + .mdv-menu__group {
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.mdv-menu__group-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px 5px;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  transition:
+    background var(--dur-fast) var(--easing),
+    color var(--dur-fast) var(--easing);
+}
+
+.mdv-menu__group-trigger:hover {
+  background: color-mix(in srgb, var(--surface-hover) 58%, transparent);
+  color: var(--fg);
+}
+
+.mdv-menu__group-trigger svg {
+  transform: rotate(0deg);
+  transition: transform var(--dur-base) var(--easing);
+}
+
+.mdv-menu__group.is-open .mdv-menu__group-trigger svg {
+  transform: rotate(90deg);
+}
+
+.mdv-menu__group-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition:
+    grid-template-rows var(--dur-base) var(--easing),
+    opacity var(--dur-base) var(--easing);
+}
+
+.mdv-menu__group.is-open .mdv-menu__group-body {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.mdv-menu__group-inner {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
 .mdv-menu__label {
   font-family: var(--font-mono);
   font-size: 10px;
@@ -127,6 +190,13 @@
   height: 1px;
   background: var(--border);
   margin: 4px 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mdv-menu__group-trigger svg,
+  .mdv-menu__group-body {
+    transition: none;
+  }
 }
 
 .mdv-menu__switch {
@@ -272,4 +342,3 @@
   outline-offset: 4px;
   border-radius: 8px;
 }
-

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -30,6 +30,34 @@
   color-scheme: light;
 }
 
+/* mono — plain black/white with neutral greys */
+:root[data-theme="mono"] {
+  --bg: #ffffff;
+  --bg-rgb: 255, 255, 255;
+  --fg: #111111;
+  --muted: #6f6f6f;
+  --border: #d9d9d9;
+  --accent: #111111;
+  --surface: #f5f5f5;
+  --surface-hover: #ececec;
+  --shadow-soft: 0 1px 2px rgba(17, 17, 17, 0.05), 0 2px 8px rgba(17, 17, 17, 0.04);
+  color-scheme: light;
+}
+
+/* mono dark — reverse mono for low-light writing */
+:root[data-theme="mono-dark"] {
+  --bg: #111111;
+  --bg-rgb: 17, 17, 17;
+  --fg: #f7f7f7;
+  --muted: #a3a3a3;
+  --border: #333333;
+  --accent: #ffffff;
+  --surface: #191919;
+  --surface-hover: #262626;
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.42), 0 2px 8px rgba(0, 0, 0, 0.3);
+  color-scheme: dark;
+}
+
 /* catppuccin frappé — soft cool dark, mauve signature (distinct from macchiato's peach) */
 :root[data-theme="frappe"] {
   --bg: #303446;            /* base */
@@ -126,6 +154,62 @@
   --surface: #1f1d2e;       /* surface */
   --surface-hover: #26233a; /* overlay */
   --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.28);
+  color-scheme: dark;
+}
+
+/* claude-inspired — warm parchment + terracotta */
+:root[data-theme="claude"] {
+  --bg: #f5f4ed;
+  --bg-rgb: 245, 244, 237;
+  --fg: #2b2118;
+  --muted: #8a7a6a;
+  --border: #ded8cb;
+  --accent: #c96442;
+  --surface: #ebe6dc;
+  --surface-hover: #e0d8ca;
+  --shadow-soft: 0 1px 2px rgba(43, 33, 24, 0.06), 0 2px 8px rgba(43, 33, 24, 0.05);
+  color-scheme: light;
+}
+
+/* codex-inspired — openai black/white with a restrained green accent */
+:root[data-theme="codex"] {
+  --bg: #0f0f0f;
+  --bg-rgb: 15, 15, 15;
+  --fg: #f4f4f0;
+  --muted: #9a9a94;
+  --border: #2d2d2a;
+  --accent: #10a37f;
+  --surface: #171715;
+  --surface-hover: #242420;
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.48), 0 2px 8px rgba(0, 0, 0, 0.32);
+  color-scheme: dark;
+}
+
+/* gemini-inspired — blue/violet AI glow kept quiet for writing */
+:root[data-theme="gemini"] {
+  --bg: #f6f8ff;
+  --bg-rgb: 246, 248, 255;
+  --fg: #202124;
+  --muted: #7b8193;
+  --border: #d8def2;
+  --accent: #6f7ee8;
+  --surface: #eef2ff;
+  --surface-hover: #e2e8ff;
+  --shadow-soft: 0 1px 2px rgba(71, 150, 227, 0.08), 0 2px 10px rgba(145, 119, 199, 0.08);
+  color-scheme: light;
+}
+
+/* cursor-inspired — warm off-white and near-black editor neutrals */
+:root[data-theme="cursor"] {
+  --bg: #14120b;
+  --bg-rgb: 20, 18, 11;
+  --fg: #f7f7f4;
+  --muted: #a5a197;
+  --border: #363326;
+  --accent: #f7f7f4;
+  --surface: #1d1b13;
+  --surface-hover: #26251e;
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary
- Fix macOS Open With/default-handler launches opening the selected markdown file reliably.
- Add mono/mono dark plus grouped animated theme dropdowns and AI-inspired palettes.
- Wrap long rendered code lines in preview and PDF export.
- Prepare v1.5.2 release notes and version bump.

## Issues
- Addresses #42
- Addresses #41
- Partially addresses #40: code block wrapping is fixed; i18n and tabs stay as roadmap-sized features.

## Test Plan
- bun test
- bun run build
- cargo check