### PR TITLE
fix: align packaged app binary name

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
+  "mainBinaryName": "marka.md",
   "version": "1.5.2",
   "identifier": "com.mattenarle.markamd",
   "build": {


### PR DESCRIPTION
## Summary
- sets Tauri `mainBinaryName` to `marka.md`
- keeps the public product name, window title, app bundle name, and download naming aligned around `marka.md`

Closes #44 when merged.

## Why
The existing macOS bundle already had:
- `CFBundleName`: `marka.md`
- `CFBundleDisplayName`: `marka.md`
- `CFBundleExecutable`: `marka`

That executable name can surface as the code-name-looking app name in places like Spotlight. This makes the release binary name explicit too.

## Checks
- bun test
- bun run build
- git diff --check
- bun run tauri build --no-bundle

The Tauri no-bundle build completed and produced:

```text
src-tauri/target/release/marka.md
```
