### PR TITLE
chore(release): prepare v1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 - **what's new toast** — first launch after update now points users straight to the changelog
 - **pdf export polish** — cleaner document margins, no browser-added date/time/path headers, and rendered mermaid diagrams
 - **theme polish** — mono / mono dark, animated grouped theme menu, and AI-inspired Claude / Codex / Gemini / Cursor palettes
+- **file tabs + languages** — open multiple notes, switch between them quickly, and use the app in more interface languages
 - **code block wrapping** — long rendered code lines wrap in preview and PDF export
-- **macOS file handling** — default-handler launches open the selected markdown file reliably
+- **macOS app naming + file handling** — packaged builds use `marka.md` consistently and default-handler launches open the selected markdown file reliably
 
 **next**:
 - native/silent PDF generation, so export does not depend on the browser print dialog

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.5.2"
+version = "1.5.3"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
   "mainBinaryName": "marka.md",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/lib/release-notes.ts
+++ b/src/lib/release-notes.ts
@@ -1,7 +1,7 @@
 export const CHANGELOG_URL = "https://markamd.vercel.app/changelog";
 
 const WHATS_NEW_TOAST_BY_MINOR: Record<string, string> = {
-  "1.5": "context tray is here - stage files, copy one AI-ready bundle",
+  "1.5": "file tabs, more languages, and cleaner app naming are here",
 };
 
 export function getWhatsNewToastMessage(version: string): string {

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
 import { getWhatsNewToastMessage } from "../src/lib/release-notes";
 
-test("calls out the context tray in the v1.5 what's-new toast", () => {
-  expect(getWhatsNewToastMessage("1.5.0")).toBe(
-    "v1.5.0: context tray is here - stage files, copy one AI-ready bundle",
+test("calls out the latest v1.5 polish in the what's-new toast", () => {
+  expect(getWhatsNewToastMessage("1.5.3")).toBe(
+    "v1.5.3: file tabs, more languages, and cleaner app naming are here",
   );
 });
 


### PR DESCRIPTION
## Summary
- bump app/package/Tauri/Cargo metadata to v1.5.3
- refresh the v1.5 what's-new toast and README highlights for tabs, languages, and app naming

## Checks
- bun test
- bun run build
- bun run tauri build --no-bundle
