### PR TITLE
fix: show dot-prefixed tool folders in sidebar

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,23 @@
     "dialog:default",
     "fs:default",
     {
+      "identifier": "fs:scope",
+      "allow": [
+        { "path": "**/.agent" },
+        { "path": "**/.agent/**" },
+        { "path": "**/.claude" },
+        { "path": "**/.claude/**" },
+        { "path": "**/.codex" },
+        { "path": "**/.codex/**" },
+        { "path": "**/.cursor" },
+        { "path": "**/.cursor/**" },
+        { "path": "**/.github" },
+        { "path": "**/.github/**" },
+        { "path": "**/.vscode" },
+        { "path": "**/.vscode/**" }
+      ]
+    },
+    {
       "identifier": "fs:allow-read-text-file",
       "allow": [{ "path": "**" }]
     },

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -66,8 +66,8 @@ export function joinPath(parent: string, child: string): string {
 
 export async function listFolder(path: string): Promise<FileEntry[]> {
   const entries = await readDir(path);
-  return entries
-    .filter((e) => !e.name.startsWith("."))
+  return (entries || [])
+    .filter((e) => e?.name && isVisibleTreeEntryName(e.name))
     .map((e) => ({
       name: e.name,
       path: joinPath(path, e.name),
@@ -85,6 +85,20 @@ export type FlatFileEntry = {
   /** path relative to the walk root, for display ("notes/ideas.md") */
   rel: string;
 };
+
+/** Modern dev/AI tool folders that start with a dot but are not hidden files. */
+const DOT_PREFIX_ALLOWLIST = new Set([
+  ".agent",
+  ".claude",
+  ".codex",
+  ".cursor",
+  ".github",
+  ".vscode",
+]);
+
+export function isVisibleTreeEntryName(name: string): boolean {
+  return !name.startsWith(".") || DOT_PREFIX_ALLOWLIST.has(name);
+}
 
 const WALK_SKIP = new Set([
   "node_modules",
@@ -113,7 +127,7 @@ export async function walkSupportedTextFiles(root: string): Promise<FlatFileEntr
     }
     for (const e of entries) {
       if (out.length >= WALK_MAX_FILES) return;
-      if (e.name.startsWith(".")) continue;
+      if (!isVisibleTreeEntryName(e.name)) continue;
       if (e.isDirectory && WALK_SKIP.has(e.name)) continue;
       const childPath = joinPath(dir, e.name);
       const childRel = relPrefix ? `${relPrefix}${sep}${e.name}` : e.name;

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { isVisibleTreeEntryName } from "../src/lib/files";
+
+test("shows common dot-prefixed tool folders", () => {
+  for (const name of [".agent", ".claude", ".codex", ".cursor", ".github", ".vscode"]) {
+    expect(isVisibleTreeEntryName(name)).toBe(true);
+  }
+});
+
+test("keeps noisy hidden entries filtered", () => {
+  for (const name of [".git", ".DS_Store", ".cache", ".env"]) {
+    expect(isVisibleTreeEntryName(name)).toBe(false);
+  }
+});
+
+test("shows regular entries", () => {
+  expect(isVisibleTreeEntryName("notes")).toBe(true);
+  expect(isVisibleTreeEntryName("readme.md")).toBe(true);
+});


### PR DESCRIPTION
## Summary

- show common dot-prefixed AI and dev tool folders in the sidebar:
  - `.agent`
  - `.claude`
  - `.codex`
  - `.cursor`
  - `.github`
  - `.vscode`
- allow nested files and folders inside these directories through the Tauri filesystem scope
- keep noisy hidden entries such as `.git`, `.DS_Store`, `.cache`, and `.env` filtered
- add focused test coverage for visible and hidden dot-prefixed entries

## Testing

- `bun test`
- `bun run build`
- `cargo check`
- `git diff --check`

Fixes #49