### PR TITLE
docs: add contributor guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,21 @@
   <img src="https://img.shields.io/badge/notarized-Apple%20Developer-orange?style=flat-square" alt="notarized" />
 </p>
 
-a cross-platform (**macOS · Windows · Linux**) markdown editor specialized for **ai context management**. live editor on the left (codemirror 6), rendered preview on the right (markdown-it + shiki + mermaid), and a context tray for staging multiple notes into one AI-ready bundle. minimal chrome, grouped themes (neutral + catppuccin + ai-inspired + crafted), orange octopus mascot. ~10 mb bundle, ~240 mb resident — lean for a tauri app.
+a cross-platform (**macOS · Windows · Linux**) markdown editor specialized for **ai context management**. live editor, rendered preview, file tabs, csv preview, grouped themes, and a context tray for staging multiple notes into one AI-ready bundle.
 
 > built around one loop: **collect notes → write → share with ai**. nothing leaves your machine until you copy.
 
-works with claude, chatgpt, gemini, your local agent — anywhere that reads plain markdown.
+works with claude, chatgpt, gemini, local agents, and anything that reads plain markdown.
 
 ## features
 
-- **live preview** — ~50 ms render, shiki code highlighting (36 langs, lazy-loaded), mermaid diagrams
+- **live preview** — fast markdown rendering, shiki code highlighting, mermaid diagrams
+- **file tabs** — keep multiple notes open and switch quickly
 - **csv preview** — open `.csv` files as a capped, read-only table for quick data checks beside your notes
-- **grouped themes** — mono, mono dark, catppuccin family, crafted palettes, plus AI-inspired Claude / Codex / Gemini / Cursor themes · animated sections + hover-to-preview
+- **grouped themes** — mono, catppuccin, crafted palettes, plus Claude / Codex / Gemini / Cursor-inspired themes
 - **reading mode** — ⌘. distraction-free preview with iA-style typography
 - **editor-only mode** — ⌘⇧. hide the preview when you want to focus on writing
-- **vim mode** — opt-in via theme menu · NORMAL/INSERT/VISUAL/REPLACE pill in the status bar
+- **vim mode** — opt-in via the theme menu
 - **find** — ⌘f works in BOTH editor (codemirror) and reading mode (text-node walker w/ live highlights)
 - **command palette** — ⌘k, fuzzy + grouped
 - **ide-style sidebar** — drag-to-move, right-click rename / new / delete, ⌘⌥Z undo
@@ -51,16 +52,14 @@ works with claude, chatgpt, gemini, your local agent — anywhere that reads pla
 
 [download the latest release →](https://github.com/mattenarle10/markamd/releases/latest)
 
-### macOS (notarized + auto-updating, universal arch coverage)
+### macOS
 
 - **apple silicon** (M1/M2/M3/M4): grab `marka.md.dmg` → drag **marka.md.app** into `/Applications` → open.
 - **intel mac**: grab `marka.md_intel.dmg` → same install steps.
 
 ### Windows (10+, x64)
 
-grab `marka.md_*-setup.exe` → run.
-
-Windows SmartScreen may show "Windows protected your PC". Click **More info** → **Run anyway**. marka.md is free + MIT — we don't sign Windows builds (paid certs aren't worth it for a free OSS project). Full source is right here if you'd rather build it yourself.
+grab `marka.md_*-setup.exe` → run. Windows SmartScreen may ask for confirmation because the Windows build is unsigned.
 
 ### Linux (x86_64)
 
@@ -70,11 +69,9 @@ three flavors, pick what fits your distro:
 - **.deb** (Debian / Ubuntu / Mint / Pop!_OS): `sudo dpkg -i marka.md_*_amd64.deb`
 - **.rpm** (Fedora / RHEL / Rocky / openSUSE): `sudo dnf install marka.md-*.x86_64.rpm`
 
-no signing required on Linux — it's the freedom platform 🐧
-
 ### from source
 
-requires bun (or npm), rust toolchain. on macOS: xcode command line tools. on Windows: MSVC build tools (Visual Studio installer → "Desktop development with C++"). on Linux: `libwebkit2gtk-4.1-dev libsoup-3.0-dev` + friends.
+requires bun, rust, and platform build tools. on Linux, install `libwebkit2gtk-4.1-dev libsoup-3.0-dev` and related Tauri deps.
 
 ```sh
 bun install
@@ -120,27 +117,14 @@ shortcuts shown with **macOS** modifiers below. on **Windows / Linux**, substitu
 
 ## project structure
 
-```
-src/
-├── app.tsx              # shell — composes hooks + renders layout
-├── components/
-│   ├── primitives/      # button, icon, popover, kbd, shortcut, tooltip
-│   ├── chrome/          # title-bar, breadcrumb, status-bar, logo
-│   ├── editor/          # editor, preview, splitter, reading-find
-│   ├── files/           # sidebar, file-tree, folder-node, editable-row, sidebar-search, context-menu
-│   └── overlays/        # palette, help, about, welcome, drop, toast
-├── hooks/                # use-file-session, use-file-ops, use-update-flow, use-context-menu,
-│                        # use-overlays, use-notifications, use-shortcuts, use-file-watcher,
-│                        # use-sync-scroll, use-debounced, use-persisted-state
-├── lib/                  # markdown, theme, platform, files, commands, pdf-export, updater,
-│                        # window-drag, storage, bundle, demo
-├── styles/               # tokens, globals, per-domain css (chrome/, editor/, files/, overlays/, shared/)
-└── assets/mascot/        # in-app sprites
-src-tauri/                # rust shell, tauri config, capabilities
-.github/workflows/        # release.yml (matrix build) + ci.yml + dependabot
-```
+- `src/components` — chrome, editor, files, overlays, and primitives
+- `src/hooks` — app state, file session, shortcuts, file watcher, sync scroll
+- `src/lib` — markdown, themes, files, commands, pdf export, updater, storage
+- `src/styles` — domain-scoped css for chrome, editor, files, overlays, shared UI
+- `src-tauri` — rust shell, capabilities, tauri config
+- `.github/workflows` — ci, release, dependabot
 
-every folder exports its public api via `index.ts`. path alias `@/*` resolves to `src/*`. state lives in cohesive custom hooks under `src/hooks/`; `app.tsx` is mostly composition + jsx.
+folders export their public api via `index.ts`. path alias `@/*` resolves to `src/*`.
 
 ## roadmap
 
@@ -159,11 +143,30 @@ per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 - native/silent PDF generation, so export does not depend on the browser print dialog
 - optional richer context bundle presets for agents with stricter prompt formats
 
-contributions welcome — see [feedback](#feedback) below to suggest priorities.
+## contributors
+
+PRs are welcome. The best contributions are small, focused, and easy to test.
+
+Good places to help:
+
+- bug fixes from the [issue tracker](https://github.com/mattenarle10/markamd/issues)
+- platform polish for Windows, Linux, and Intel macOS
+- markdown / mermaid / pdf edge cases
+- translations and copy cleanup
+- small UX improvements with screenshots or short screen recordings
+
+Before opening a PR:
+
+- keep one behavior change per PR when possible
+- include screenshots for UI changes
+- update help/about/readme copy when the user-facing surface changes
+- run `bun test`, `bun run build`, and `cargo check --release` from `src-tauri`
+
+For larger ideas, open a feedback issue first so we can keep the app focused.
 
 ## privacy
 
-local-first. nothing ever leaves your machine. no telemetry, no analytics, no accounts, no cloud sync. your `.md` files stay on disk. clipboard transfers happen only when you press ⌘⇧C — and then they're yours, going wherever you paste them.
+local-first. no telemetry, no accounts, no cloud sync. your `.md` files stay on disk, and clipboard transfers happen only when you copy.
 
 see [the full privacy notice](https://markamd.vercel.app/privacy) for the website analytics caveat (vercel speed insights, cookieless).
 
@@ -176,16 +179,9 @@ ideas, bugs, or just want to say hi?
 - **landing page hub** → [markamd.vercel.app/feedback](https://markamd.vercel.app/feedback)
 - **security issues** → [SECURITY.md](./SECURITY.md)
 
-i read everything. PRs welcome.
-
 ## support
 
-marka.md is free + MIT, and intends to stay that way. if it saves you time wrangling AI context:
-
-- ⭐ [star the repo](https://github.com/mattenarle10/markamd) — biggest single signal
-- 🗣️ tell another dev / share it
-
-both appreciated, neither required. 🐙
+marka.md is free + MIT. if it saves you time, [star the repo](https://github.com/mattenarle10/markamd) or share it with another dev.
 
 ## license
 


### PR DESCRIPTION
## Summary
- trim verbose README copy around positioning, install notes, project structure, privacy, and support
- add a focused contributors section with good PR areas and local verification commands
- keep the README centered on features, install, and contribution flow

## Checks
- git diff --check