### PR TITLE
chore(release): prepare v1.5.5

### DIFF
--- a/docs/release-notes/v1.5.5.md
+++ b/docs/release-notes/v1.5.5.md
@@ -1,0 +1,19 @@
+# v1.5.5
+
+v1.5.5 is a small workflow and navigation polish release.
+
+## added
+
+- **Copy Path / Copy Relative Path**: sidebar context menus can copy absolute or root-relative paths.
+- **Reveal in File Manager**: open a selected file or folder in Finder, Explorer, or the Linux file manager.
+- **Breadcrumb view controls**: reading mode, titlebar visibility, and the theme menu now live beside the file actions.
+
+## improved
+
+- Hidden-but-useful tool folders like `.github`, `.vscode`, `.cursor`, `.claude`, and `.codex` now show in the sidebar.
+- Reading mode keeps its exit controls reachable even when the titlebar is hidden.
+- README contributor guidance is shorter and clearer for first-time PRs.
+
+## security
+
+- Updated the indirect Rust `tar` dependency from `0.4.45` to `0.4.46`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.5.4"
+version = "1.5.5"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
   "mainBinaryName": "marka.md",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- bump app/package versions to 1.5.5
- add v1.5.5 release notes

## Checks
- bun test
- bun run build
- cargo check --release
- git diff --check