### PR TITLE
feat(ui): improve preview and sidebar interactions

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import {
   useNotifications,
   useOverlays,
   usePersistedState,
+  useScrollMemory,
   useSelectionSyncText,
   useShortcuts,
   useSyncScroll,
@@ -430,6 +431,7 @@ export function App() {
 
   // proportional editor <-> preview scroll sync; rebinds when active file changes
   useSyncScroll({ rebindKey: activePath ?? "untitled" });
+  useScrollMemory(activePath);
 
   const editorViewRef = useRef<EditorView | null>(null);
   useSelectionSyncText(editorViewRef, activePath ?? "untitled");
@@ -915,7 +917,7 @@ export function App() {
                 </div>
               ) : (
                 <Splitter
-                  left={<Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} />}
+                  left={<Editor value={source} onChange={setSource} vimOn={vimOn} onVimMode={setVimMode} viewRef={editorViewRef} />}
                   right={<Preview source={debouncedPreview} filePath={activePath} />}
                 />
               )}

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { readFile } from "@tauri-apps/plugin-fs";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { ensureMarkdownReady, renderMarkdown, useI18n, useTheme } from "@/lib";
 import inspectUrl from "@/assets/mascot/inspect.png";
 import { renderMermaidBlocks } from "@/lib/mermaid";
@@ -198,11 +199,16 @@ export function Preview({ source, filePath }: PreviewProps) {
       const a = (e.target as HTMLElement).closest("a");
       if (!a) return;
       const href = a.getAttribute("href");
-      if (!href?.startsWith("#")) return;
-      e.preventDefault();
-      const id = decodeURIComponent(href.slice(1));
-      const target = article.querySelector(`[id="${CSS.escape(id)}"]`) ?? article.querySelector(`[id="${id}"]`);
-      if (target) target.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (!href) return;
+      if (href.startsWith("#")) {
+        e.preventDefault();
+        const id = decodeURIComponent(href.slice(1));
+        const target = article.querySelector(`[id="${CSS.escape(id)}"]`) ?? article.querySelector(`[id="${id}"]`);
+        if (target) target.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else if (/^https?:\/\//.test(href)) {
+        e.preventDefault();
+        void openUrl(href);
+      }
     };
     article.addEventListener("click", onClick);
     return () => article.removeEventListener("click", onClick);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { usePersistedState } from "./use-persisted-state";
 export { useShortcuts, type ShortcutHandler } from "./use-shortcuts";
 export { useSyncScroll } from "./use-sync-scroll";
 export { useSelectionSyncText } from "./use-selection-sync-text";
+export { useScrollMemory } from "./use-scroll-memory";

--- a/src/hooks/use-scroll-memory.ts
+++ b/src/hooks/use-scroll-memory.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from "react";
+
+type ScrollPosition = {
+  editor: number;
+  preview: number;
+};
+
+export function useScrollMemory(activePath: string | null): void {
+  const memory = useRef(new Map<string, ScrollPosition>());
+
+  useEffect(() => {
+    const path = activePath;
+    if (!path) return;
+
+    const editorScroller = document.querySelector<HTMLElement>(".mdv-editor .cm-scroller");
+    const preview = document.querySelector<HTMLElement>(".mdv-preview");
+
+    const onEditorScroll = () => {
+      if (!editorScroller) return;
+      const prev = memory.current.get(path) ?? { editor: 0, preview: 0 };
+      memory.current.set(path, { ...prev, editor: editorScroller.scrollTop });
+    };
+    const onPreviewScroll = () => {
+      if (!preview) return;
+      const prev = memory.current.get(path) ?? { editor: 0, preview: 0 };
+      memory.current.set(path, { ...prev, preview: preview.scrollTop });
+    };
+
+    editorScroller?.addEventListener("scroll", onEditorScroll, { passive: true });
+    preview?.addEventListener("scroll", onPreviewScroll, { passive: true });
+
+    return () => {
+      editorScroller?.removeEventListener("scroll", onEditorScroll);
+      preview?.removeEventListener("scroll", onPreviewScroll);
+    };
+  }, [activePath]);
+
+  useEffect(() => {
+    const saved = activePath ? memory.current.get(activePath) : null;
+    if (!saved) return;
+
+    const id = window.requestAnimationFrame(() => {
+      const editorScroller = document.querySelector<HTMLElement>(".mdv-editor .cm-scroller");
+      const preview = document.querySelector<HTMLElement>(".mdv-preview");
+      if (editorScroller) editorScroller.scrollTop = saved.editor;
+      if (preview) preview.scrollTop = saved.preview;
+    });
+
+    return () => window.cancelAnimationFrame(id);
+  }, [activePath]);
+}

--- a/src/hooks/use-selection-sync-text.ts
+++ b/src/hooks/use-selection-sync-text.ts
@@ -1,41 +1,127 @@
 import { useEffect, type RefObject } from "react";
 import { EditorView } from "@codemirror/view";
 
-function findTextInDOM(root: HTMLElement, text: string): Range | null {
+type TextPoint = {
+  node: Text;
+  start: number;
+  end: number;
+};
+
+function normalizeTypography(text: string): string {
+  return text
+    .replace(/\u00a0/g, " ")
+    .replace(/[“”]/g, "\"")
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, " ");
+}
+
+function normalizeChar(char: string): string {
+  if (char === "\u00a0" || /\s/.test(char)) return " ";
+  if (char === "“" || char === "”") return "\"";
+  if (char === "‘" || char === "’") return "'";
+  return char;
+}
+
+function buildTextMap(nodes: Text[]): { text: string; points: TextPoint[] } {
+  let text = "";
+  const points: TextPoint[] = [];
+  let lastWasSpace = false;
+
+  for (const node of nodes) {
+    const content = node.textContent ?? "";
+    for (let i = 0; i < content.length; i += 1) {
+      const char = normalizeChar(content[i]);
+      if (char === " ") {
+        if (lastWasSpace) continue;
+        lastWasSpace = true;
+      } else {
+        lastWasSpace = false;
+      }
+
+      text += char;
+      points.push({ node, start: i, end: i + 1 });
+    }
+  }
+
+  return { text, points };
+}
+
+function buildSourceMap(source: string): { text: string; offsets: number[] } {
+  let text = "";
+  const offsets: number[] = [];
+  let lastWasSpace = false;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = normalizeChar(source[i]);
+    if (char === " ") {
+      if (lastWasSpace) continue;
+      lastWasSpace = true;
+    } else {
+      lastWasSpace = false;
+    }
+
+    text += char;
+    offsets.push(i);
+  }
+
+  return { text, offsets };
+}
+
+function findInNormalizedSource(source: string, needle: string, targetOffset = 0): number {
+  const { text, offsets } = buildSourceMap(source);
+  const idx = nearestOccurrence(text, needle, targetOffset);
+  return idx >= 0 ? offsets[idx] : -1;
+}
+
+function stripMarkdown(text: string): string {
+  return normalizeTypography(text)
+    .replace(/!\[[^\]]*]\([^)]*\)/g, "")
+    .replace(/\[([^\]]+)]\([^)]*\)/g, "$1")
+    .replace(/[`*_~]/g, "")
+    .replace(/^[\s>#*-]+/gm, "")
+    .replace(/\|/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function nearestOccurrence(haystack: string, needle: string, targetOffset: number): number {
+  let best = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  let idx = haystack.indexOf(needle);
+
+  while (idx >= 0) {
+    const distance = Math.abs(idx - targetOffset);
+    if (distance < bestDistance) {
+      best = idx;
+      bestDistance = distance;
+    }
+    idx = haystack.indexOf(needle, idx + Math.max(needle.length, 1));
+  }
+
+  return best;
+}
+
+function findTextInDOM(root: HTMLElement, text: string, targetOffset = 0): Range | null {
   if (!text || !text.trim()) return null;
+  const needle = normalizeTypography(text).trim();
+  if (!needle) return null;
+
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   const nodes: Text[] = [];
   let n: Node | null;
   while ((n = walker.nextNode())) nodes.push(n as Text);
 
-  const fullText = nodes.map((tn) => tn.textContent ?? "").join("");
-  const idx = fullText.indexOf(text);
+  const { text: fullText, points } = buildTextMap(nodes);
+  const idx = nearestOccurrence(fullText, needle, targetOffset);
   if (idx < 0) return null;
 
-  let pos = 0;
-  let startNode: Text | null = null;
-  let startOff = 0;
-  let endNode: Text | null = null;
-  let endOff = 0;
+  const startPoint = points[idx];
+  const endPoint = points[idx + needle.length - 1];
+  if (!startPoint || !endPoint) return null;
 
-  for (const tn of nodes) {
-    const len = tn.textContent?.length ?? 0;
-    if (!startNode && pos + len > idx) {
-      startNode = tn;
-      startOff = idx - pos;
-    }
-    if (!endNode && pos + len >= idx + text.length) {
-      endNode = tn;
-      endOff = idx + text.length - pos;
-      break;
-    }
-    pos += len;
-  }
-
-  if (!startNode || !endNode) return null;
   const range = document.createRange();
-  range.setStart(startNode, startOff);
-  range.setEnd(endNode, endOff);
+  range.setStart(startPoint.node, startPoint.start);
+  range.setEnd(endPoint.node, endPoint.end);
   return range;
 }
 
@@ -61,12 +147,31 @@ export function useSelectionSyncText(
       const anchor = sel.anchorNode;
 
       if (prose && anchor && prose.contains(anchor)) {
-        // Preview → Editor
         const view = viewRef.current;
         if (!view) return;
-        const src = view.state.doc.toString();
-        const idx = src.indexOf(text);
+
+        const doc = view.state.doc;
+        const anchorElement = anchor instanceof Element ? anchor : anchor.parentElement;
+        const block = anchorElement?.closest<HTMLElement>("[data-sline]");
+        const needle = normalizeTypography(text).trim();
+        let idx = -1;
+
+        if (block) {
+          const startLine = Number(block.dataset.sline);
+          const endLine = Number(block.dataset.eline ?? startLine + 1);
+
+          if (Number.isFinite(startLine) && startLine + 1 <= doc.lines) {
+            const from = doc.line(startLine + 1).from;
+            const toLine = Math.min(Math.max(endLine, startLine + 1), doc.lines);
+            const to = doc.line(toLine).to;
+            const localIdx = findInNormalizedSource(doc.sliceString(from, to), needle);
+            if (localIdx >= 0) idx = from + localIdx;
+          }
+        }
+
+        if (idx < 0) idx = findInNormalizedSource(doc.toString(), needle);
         if (idx < 0) return;
+
         view.dispatch({
           selection: { anchor: idx, head: idx + text.length },
           effects: EditorView.scrollIntoView(idx, { y: "center" }),
@@ -75,17 +180,43 @@ export function useSelectionSyncText(
       }
 
       if (editorContent && anchor && editorContent.contains(anchor)) {
-        // Editor → Preview
         if (!prose) return;
-        const range = findTextInDOM(prose, text);
+        const view = viewRef.current;
+        if (!view) return;
+
+        const stripped = stripMarkdown(text);
+        if (!stripped) return;
+
+        const doc = view.state.doc;
+        const selFrom = view.state.selection.main.from;
+        const selLine = doc.lineAt(selFrom).number - 1;
+        let scope: HTMLElement | null = null;
+
+        for (const el of prose.querySelectorAll<HTMLElement>("[data-sline]")) {
+          const startLine = Number(el.dataset.sline);
+          const endLine = Number(el.dataset.eline ?? startLine + 1);
+          if (selLine >= startLine && selLine < endLine) {
+            if (!scope || scope.contains(el)) scope = el;
+          }
+        }
+
+        let range: Range | null = null;
+        if (scope) {
+          const startLine = Number(scope.dataset.sline);
+          if (Number.isFinite(startLine) && startLine + 1 <= doc.lines) {
+            const from = doc.line(startLine + 1).from;
+            const localOffset = stripMarkdown(doc.sliceString(from, selFrom)).length;
+            range = findTextInDOM(scope, stripped, localOffset);
+          }
+        }
+
+        range ??= findTextInDOM(prose, stripped);
         if (!range) return;
+
         const domSel = window.getSelection();
         if (domSel) {
           domSel.removeAllRanges();
           domSel.addRange(range);
-          // scroll the matched element into view
-          const el = range.startContainer.parentElement;
-          el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
         }
       }
     };

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -121,6 +121,18 @@ const md = new MarkdownIt({
 md.use(taskLists, { enabled: false, label: true });
 md.use(mark);
 
+// Stamp block tokens with source line ranges so preview DOM can map back to
+// markdown source positions for selection sync.
+md.core.ruler.push("source_lines", (state) => {
+  for (const token of state.tokens) {
+    if (token.map && token.nesting !== -1) {
+      token.attrSet("data-sline", String(token.map[0]));
+      token.attrSet("data-eline", String(token.map[1]));
+    }
+  }
+  return true;
+});
+
 // GitHub-style heading slugs for TOC anchor navigation
 const slugify = (text: string): string =>
   text

--- a/src/styles/files/sidebar.css
+++ b/src/styles/files/sidebar.css
@@ -71,9 +71,30 @@
 
 .mdv-sidebar__body {
   flex: 1;
-  overflow: auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: 2px 0 16px;
   transition: box-shadow var(--dur-fast) var(--easing);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128, 128, 128, 0.35) transparent;
+}
+
+.mdv-sidebar__body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.mdv-sidebar__body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.mdv-sidebar__body::-webkit-scrollbar-thumb {
+  background: rgba(128, 128, 128, 0.35);
+  border-radius: 4px;
+}
+
+.mdv-sidebar__body::-webkit-scrollbar-thumb:hover {
+  background: rgba(128, 128, 128, 0.6);
 }
 
 .mdv-sidebar__body.is-root-drop {


### PR DESCRIPTION
## Summary
- extracts the useful runtime UX pieces from #62 onto a clean branch
- opens external preview links in the default browser
- improves editor/preview text selection sync using rendered source-line metadata
- remembers editor and preview scroll position per file
- makes the sidebar body scroll cleanly

## Notes
- keeps `macOSPrivateApi` enabled
- keeps the existing `1.5.8` version, no release bump included
- credits the original contributor in the commit trailer

## Test plan
- `bun test`
- `bun run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- local app is running on the existing Tauri dev stack for manual testing