### PR TITLE
feat(preview): add PlantUML blocks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "markdown-it-mark": "^4.0.0",
         "markdown-it-task-lists": "^2.1.1",
         "mermaid": "^11.15.0",
+        "plantuml-encoder": "^1.4.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "shiki": "^4.0.2",
@@ -609,6 +610,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "plantuml-encoder": ["plantuml-encoder@1.4.0", "", {}, "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "markdown-it-mark": "^4.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "mermaid": "^11.15.0",
+    "plantuml-encoder": "^1.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "shiki": "^4.0.2"

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -4,6 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { ensureMarkdownReady, renderMarkdown, useI18n, useTheme } from "@/lib";
 import inspectUrl from "@/assets/mascot/inspect.png";
 import { renderMermaidBlocks } from "@/lib/mermaid";
+import { decoratePlantUmlBlocks } from "@/lib/plantuml";
 import { basename, isCsvPath } from "@/lib";
 import { CsvPreview } from "./csv-preview";
 import {
@@ -173,7 +174,12 @@ export function Preview({ source, filePath }: PreviewProps) {
 
   useEffect(() => {
     if (!articleRef.current || csvPreview) return;
-    return decorateCodeBlocks(articleRef.current);
+    const cleanupCode = decorateCodeBlocks(articleRef.current);
+    const cleanupPlantUml = decoratePlantUmlBlocks(articleRef.current);
+    return () => {
+      cleanupCode();
+      cleanupPlantUml();
+    };
   }, [html, csvPreview]);
 
   useEffect(() => {

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -19,6 +19,13 @@ flowchart LR
   Claude --> Idea
 \`\`\`
 
+plantuml can be previewed on demand:
+
+\`\`\`plantuml
+Alice -> Bob: hello
+Bob --> Alice: saved
+\`\`\`
+
 ---
 
 ## code

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,11 +2,23 @@ import MarkdownIt from "markdown-it";
 import mark from "markdown-it-mark";
 import taskLists from "markdown-it-task-lists";
 import { createHighlighter, type Highlighter } from "shiki";
+import { plantUmlUrl } from "./plantuml";
 import type { Theme } from "./theme";
 
 // random suffix per render — mermaid id reuse across re-renders silently fails.
 function mermaidId(): string {
   return `mdv-mermaid-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/"/g, "&quot;");
 }
 
 // allowed langs — shiki chunks load on first use via ensureLangsLoaded.
@@ -98,11 +110,13 @@ const md = new MarkdownIt({
     // mermaid blocks bypass shiki — Preview component renders them as svg
     if (lang === "mermaid") {
       const id = mermaidId();
-      const encoded = code
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
+      const encoded = escapeHtml(code);
       return `<pre class="mdv-mermaid" id="${id}"><code>${encoded}</code></pre>`;
+    }
+    if (lang === "plantuml" || lang === "puml") {
+      const source = escapeHtml(code);
+      const src = escapeAttr(plantUmlUrl(code));
+      return `<figure class="mdv-plantuml" data-src="${src}"><figcaption>plantuml</figcaption><pre><code>${source}</code></pre></figure>`;
     }
     if (!highlighter) return "";
     const loaded = highlighter.getLoadedLanguages() as readonly string[];

--- a/src/lib/plantuml.ts
+++ b/src/lib/plantuml.ts
@@ -1,0 +1,56 @@
+import { encode } from "plantuml-encoder";
+
+const PLANTUML_SVG_BASE = "https://www.plantuml.com/plantuml/svg";
+
+export function plantUmlUrl(source: string): string {
+  return `${PLANTUML_SVG_BASE}/${encode(source)}`;
+}
+
+export function decoratePlantUmlBlocks(root: HTMLElement): () => void {
+  const cleanups: Array<() => void> = [];
+  const blocks = Array.from(
+    root.querySelectorAll<HTMLElement>(".mdv-plantuml:not([data-mdv-plantuml-ready])"),
+  );
+
+  blocks.forEach((block) => {
+    const url = block.dataset.src;
+    if (!url) return;
+    block.dataset.mdvPlantumlReady = "true";
+
+    const actions = document.createElement("div");
+    actions.className = "mdv-plantuml__actions";
+
+    const load = document.createElement("button");
+    load.type = "button";
+    load.className = "mdv-plantuml__btn";
+    load.textContent = "load preview";
+
+    const note = document.createElement("span");
+    note.className = "mdv-plantuml__note";
+    note.textContent = "uses plantuml.com";
+
+    actions.append(load, note);
+    block.prepend(actions);
+
+    const onLoad = () => {
+      if (block.querySelector("img")) return;
+      const img = document.createElement("img");
+      img.className = "mdv-plantuml__img";
+      img.alt = "PlantUML diagram";
+      img.loading = "lazy";
+      img.referrerPolicy = "no-referrer";
+      img.src = url;
+      block.appendChild(img);
+      load.textContent = "reload preview";
+    };
+
+    load.addEventListener("click", onLoad);
+    cleanups.push(() => {
+      load.removeEventListener("click", onLoad);
+      actions.remove();
+      delete block.dataset.mdvPlantumlReady;
+    });
+  });
+
+  return () => cleanups.forEach((fn) => fn());
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -167,7 +167,7 @@
   "help.subtitle": "keyboard + tips",
   "help.features": "features",
   "help.feature.markdown.title": "markdown",
-  "help.feature.markdown.body": "preview, mermaid, pdf",
+  "help.feature.markdown.body": "preview, mermaid, plantuml, pdf",
   "help.feature.context.title": "context",
   "help.feature.context.body": "copy one ai-ready bundle",
   "help.feature.csv.title": "csv preview",

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -219,6 +219,68 @@
   background: var(--bg-solid, var(--bg));
 }
 
+/* PlantUML uses an explicit remote-render action so diagrams are not sent to a
+   server just by opening a local markdown file. */
+.mdv-plantuml {
+  margin: 16px 0;
+  padding: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+}
+
+.mdv-plantuml figcaption {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.mdv-plantuml pre {
+  margin: 0;
+  color: var(--muted);
+}
+
+.mdv-plantuml__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.mdv-plantuml__btn {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-solid, var(--bg));
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  cursor: pointer;
+}
+
+.mdv-plantuml__btn:hover,
+.mdv-plantuml__btn:focus-visible {
+  border-color: var(--muted);
+}
+
+.mdv-plantuml__note {
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  color: var(--muted);
+}
+
+.mdv-plantuml__img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-top: 12px;
+}
+
 .mdv-diagram-viewer {
   position: fixed;
   inset: 0;

--- a/src/types/plantuml-encoder.d.ts
+++ b/src/types/plantuml-encoder.d.ts
@@ -1,0 +1,4 @@
+declare module "plantuml-encoder" {
+  export function encode(source: string): string;
+  export function decode(encoded: string): string;
+}

--- a/tests/plantuml.test.ts
+++ b/tests/plantuml.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { renderMarkdown } from "../src/lib/markdown";
+import { plantUmlUrl } from "../src/lib/plantuml";
+
+test("builds plantuml server svg urls", () => {
+  expect(plantUmlUrl("A -> B: Hello")).toBe(
+    "https://www.plantuml.com/plantuml/svg/SrJGjLDmibBmICt9oGS0",
+  );
+});
+
+test("renders plantuml fences as explicit preview blocks", async () => {
+  const html = await renderMarkdown("```plantuml\nA -> B: Hello\n```", "latte");
+
+  expect(html).toContain('class="mdv-plantuml"');
+  expect(html).toContain("https://www.plantuml.com/plantuml/svg/");
+  expect(html).toContain("A -&gt; B: Hello");
+});


### PR DESCRIPTION
## summary
- add first-class `plantuml` / `puml` fenced blocks in markdown preview
- render PlantUML through an explicit load button, instead of auto-sending local diagram source to a remote renderer
- add demo/help copy and focused tests for PlantUML URL/render output

Closes #72.

## checks
- bun test
- bun run build

## note
PlantUML rendering uses the public PlantUML SVG endpoint after the user clicks "load preview". This keeps the app lightweight and avoids sending diagram source over the network just by opening a local file.