### PR TITLE
chore(release): prepare v1.5.10

### DIFF
--- a/docs/release-notes/v1.5.10.md
+++ b/docs/release-notes/v1.5.10.md
@@ -1,0 +1,31 @@
+# v1.5.10
+
+v1.5.10 is a diagram and workspace polish release.
+
+This release closes 3 issues: #60, #71, and #72.
+
+## added
+
+- **PlantUML preview**: `plantuml` and `puml` code fences now show an explicit `load preview` action.
+- **PlantUML viewer**: loaded PlantUML diagrams can open in the same focused zoom viewer as Mermaid.
+- **Persisted view mode**: marka.md now remembers split, reading, or editor mode across launches.
+
+## improved
+
+- **Reading mode themes**: the theme menu is available from reading mode, so palettes and text settings are easier to adjust while proofing.
+- **Context tray space**: the context tray now appears only when files are staged.
+- **Default window size**: new windows open larger for a more comfortable editor/sidebar/preview layout.
+- **Open With workflow**: file launches and existing-window handoff are smoother.
+
+## thanks
+
+- Thanks to [@renwuli](https://github.com/renwuli) for requesting PlantUML support in #72.
+- Thanks to [@mshadmanrahman](https://github.com/mshadmanrahman) for the persisted view-mode request in #71.
+- Thanks to [@Durobert](https://github.com/Durobert) for the AI-agent workflow feedback in #60.
+- Thanks to [@hoiyada7-maker](https://github.com/hoiyada7-maker) for the FILES, Open With, and single-instance workflow work that helped shape this release.
+- Thanks to everyone testing the v1.5 feedback loop.
+
+## notes
+
+- PlantUML remains explicit-load only, so local diagram text is not sent to plantuml.com just by opening a note.
+- This release keeps the current signed updater and macOS private API setup unchanged.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.5.9",
+  "version": "1.5.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.5.9"
+version = "1.5.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.5.9"
+version = "1.5.10"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
   "mainBinaryName": "marka.md",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/lib/release-notes.ts
+++ b/src/lib/release-notes.ts
@@ -1,7 +1,7 @@
 export const CHANGELOG_URL = "https://markamd.vercel.app/changelog";
 
 const WHATS_NEW_TOAST_BY_MINOR: Record<string, string> = {
-  "1.5": "preview links, selection sync, scroll memory, and sidebar polish are here",
+  "1.5": "PlantUML previews, remembered view modes, reading themes, and a cleaner context tray are here",
 };
 
 export function getWhatsNewToastMessage(version: string): string {

--- a/tests/release-notes.test.ts
+++ b/tests/release-notes.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import { getWhatsNewToastMessage } from "../src/lib/release-notes";
 
 test("calls out the latest v1.5 polish in the what's-new toast", () => {
-  expect(getWhatsNewToastMessage("1.5.9")).toBe(
-    "v1.5.9: preview links, selection sync, scroll memory, and sidebar polish are here",
+  expect(getWhatsNewToastMessage("1.5.10")).toBe(
+    "v1.5.10: PlantUML previews, remembered view modes, reading themes, and a cleaner context tray are here",
   );
 });
 


### PR DESCRIPTION
## Summary
- bump app/package metadata to v1.5.10
- add v1.5.10 release notes with thanks for #60, #71, and #72
- update the v1.5 what's-new toast copy and test

## Checks
- bun test
- bun run build
- cargo check --release

No tag/release created yet.