### PR TITLE
fix reading find refocus

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -363,6 +363,7 @@ export function App() {
 
   // ⌘F only bound while reading — CM owns it in editor mode.
   const [findOpen, setFindOpen] = useState(false);
+  const [findFocusRequest, setFindFocusRequest] = useState(0);
   const [proseEl, setProseEl] = useState<HTMLElement | null>(null);
   useEffect(() => {
     if (!readingMode) {
@@ -708,6 +709,7 @@ export function App() {
             "mod+f": (e: KeyboardEvent) => {
               e.preventDefault();
               setFindOpen(true);
+              setFindFocusRequest((v) => v + 1);
             },
           }
         : {}),
@@ -857,6 +859,7 @@ export function App() {
             <Preview source={debouncedPreview} filePath={activePath} />
             <ReadingFind
               open={findOpen}
+              focusRequest={findFocusRequest}
               onClose={() => setFindOpen(false)}
               scope={proseEl}
               contentKey={debouncedPreview}

--- a/src/components/editor/reading-find.tsx
+++ b/src/components/editor/reading-find.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 type Props = {
   /** when true, the find bar is mounted + visible */
   open: boolean;
+  /** increments when the parent wants the existing input focused again */
+  focusRequest?: number;
   /** parent calls this to close (Esc, × button, or external trigger) */
   onClose: () => void;
   /** the rendered `<article class="mdv-prose">` to search through */
@@ -23,7 +25,7 @@ type Props = {
  * Cleanup is guaranteed on unmount + close: marks are unwrapped back to plain
  * text so the next render of the prose stays clean.
  */
-export function ReadingFind({ open, onClose, scope, contentKey }: Props) {
+export function ReadingFind({ open, focusRequest = 0, onClose, scope, contentKey }: Props) {
   const [query, setQuery] = useState("");
   const [matches, setMatches] = useState<HTMLElement[]>([]);
   const [activeIdx, setActiveIdx] = useState(0);
@@ -64,13 +66,14 @@ export function ReadingFind({ open, onClose, scope, contentKey }: Props) {
     };
   }, [scope]);
 
-  // when the bar opens, focus the input + select any existing query for fast retype
+  // when the bar opens or ⌘F/Ctrl+F is pressed again, focus the input + select
+  // any existing query for fast retype.
   useEffect(() => {
     if (open) {
       inputRef.current?.focus();
       inputRef.current?.select();
     }
-  }, [open]);
+  }, [open, focusRequest]);
 
   const go = useCallback(
     (dir: 1 | -1) => {


### PR DESCRIPTION
## Summary
- refocus and select the reading-mode find input when Cmd/Ctrl+F is pressed while the find bar is already open
- keep the existing open-on-first-press behavior unchanged

## Testing
- bun test
- bun run build
- cargo check --release --manifest-path src-tauri/Cargo.toml