### PR TITLE
feat(preview): click to open images in the diagram viewer

### DIFF
--- a/src/components/editor/diagram-viewer.tsx
+++ b/src/components/editor/diagram-viewer.tsx
@@ -297,6 +297,51 @@ export function decorateMermaidBlocks(
   return () => cleanups.forEach((fn) => fn());
 }
 
+export function decorateImages(
+  root: HTMLElement,
+  onOpen: (viewer: DiagramViewerSource) => void,
+): () => void {
+  const cleanups: Array<() => void> = [];
+  const images = Array.from(
+    root.querySelectorAll<HTMLImageElement>("img:not([data-mdv-image-viewer])"),
+  );
+
+  images.forEach((img) => {
+    // PlantUML previews carry their own open affordance; mermaid renders as
+    // inline <svg>, not <img>, but guard anyway so we never double-bind.
+    if (img.closest(".mdv-plantuml") || img.closest("pre.mdv-mermaid")) return;
+
+    img.dataset.mdvImageViewer = "true";
+    img.draggable = false;
+
+    const open = () => {
+      const rect = img.getBoundingClientRect();
+      // svg <img> may report naturalWidth 0 — fall back to rendered box.
+      // fit mode (the default) never depends on these, only manual zoom does.
+      const width = img.naturalWidth || Math.max(1, Math.round(rect.width));
+      const height = img.naturalHeight || Math.max(1, Math.round(rect.height));
+      onOpen({
+        svg: `<img class="mdv-diagram-viewer__image" src="${escapeViewerAttr(img.src)}" alt="${escapeViewerAttr(img.alt || "")}" />`,
+        width,
+        height,
+      });
+    };
+
+    const onClick = (e: MouseEvent) => {
+      e.preventDefault();
+      open();
+    };
+
+    img.addEventListener("click", onClick);
+    cleanups.push(() => {
+      img.removeEventListener("click", onClick);
+      delete img.dataset.mdvImageViewer;
+    });
+  });
+
+  return () => cleanups.forEach((fn) => fn());
+}
+
 function clampDiagramScale(scale: number): number {
   return Math.min(MAX_DIAGRAM_SCALE, Math.max(MIN_DIAGRAM_SCALE, scale));
 }
@@ -354,4 +399,12 @@ function svgSize(svg: SVGSVGElement): { width: number; height: number } {
   }
   const rect = svg.getBoundingClientRect();
   return { width: Math.max(rect.width, 1), height: Math.max(rect.height, 1) };
+}
+
+function escapeViewerAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -10,6 +10,7 @@ import { basename, isCsvPath } from "@/lib";
 import { CsvPreview } from "./csv-preview";
 import {
   createDiagramViewer,
+  decorateImages,
   decorateMermaidBlocks,
   DiagramViewerOverlay,
   type DiagramViewer,
@@ -199,9 +200,11 @@ export function Preview({ source, filePath }: PreviewProps) {
     if (!articleRef.current || csvPreview) return;
     const cleanupCode = decorateCodeBlocks(articleRef.current);
     const cleanupPlantUml = decoratePlantUmlBlocks(articleRef.current, openDiagramViewer, viewerLabels);
+    const cleanupImages = decorateImages(articleRef.current, openDiagramViewer);
     return () => {
       cleanupCode();
       cleanupPlantUml();
+      cleanupImages();
     };
   }, [html, csvPreview, openDiagramViewer, viewerLabels]);
 

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -537,6 +537,10 @@
   border: 1px solid var(--border);
 }
 
+.mdv-prose img[data-mdv-image-viewer="true"] {
+  cursor: zoom-in;
+}
+
 .mdv-prose video,
 .mdv-prose audio {
   display: block;


### PR DESCRIPTION
## What

Preview-area images (`<img>`) now open in the existing fullscreen diagram viewer — the same overlay already used by Mermaid and PlantUML diagrams. Single-click any image to zoom.

## Why

The diagram viewer already supported Mermaid and PlantUML, and its CSS (`.mdv-diagram-viewer__image`) was already prepared for image content, but inline markdown images had no zoom affordance. This completes that path with the smallest possible change: **no new component, no new interaction model** — the overlay's zoom/pan/close behavior is reused as-is.

## Changes

- **`diagram-viewer.tsx`** — add `decorateImages(root, onOpen)`, mirroring `decorateMermaidBlocks` / `decoratePlantUmlBlocks`. Marks each preview `<img>`, binds single-click → `openDiagramViewer`, sets `draggable=false`. Excludes images inside `.mdv-plantuml` and `pre.mdv-mermaid` (they already have their own open affordance). SVG images (`*.svg`, `data:image/svg+xml`) work via native `<img>` SVG support; `naturalWidth` falls back to the rendered box for SVGs that report `0`.
- **`preview.tsx`** — call `decorateImages` in the existing decorate effect.
- **`prose.css`** — `cursor: zoom-in` on decorated images.

## Not changed (intentional)

- The `DiagramViewerOverlay` component itself — zoom / pan / close interactions are untouched.
- Mermaid / PlantUML wiring.
- i18n (no new keys; the shared viewer is reused).
- Rust.

## Verification

- `bun run build` (tsc + vite) ✅
- `bun test` — 24 pass, 0 fail ✅
- Manual: `bun run tauri dev`, paste `![](https://...png)` or `![](./x.svg)` into the editor, single-click the preview image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)