### PR TITLE
feat(preview): click to open images in the diagram viewer

### DIFF
--- a/src/components/editor/diagram-viewer.tsx
+++ b/src/components/editor/diagram-viewer.tsx
@@ -297,6 +297,51 @@ export function decorateMermaidBlocks(
   return () => cleanups.forEach((fn) => fn());
 }
 
+export function decorateImages(
+  root: HTMLElement,
+  onOpen: (viewer: DiagramViewerSource) => void,
+): () => void {
+  const cleanups: Array<() => void> = [];
+  const images = Array.from(
+    root.querySelectorAll<HTMLImageElement>("img:not([data-mdv-image-viewer])"),
+  );
+
+  images.forEach((img) => {
+    // PlantUML previews carry their own open affordance; mermaid renders as
+    // inline <svg>, not <img>, but guard anyway so we never double-bind.
+    if (img.closest(".mdv-plantuml") || img.closest("pre.mdv-mermaid")) return;
+
+    img.dataset.mdvImageViewer = "true";
+    img.draggable = false;
+
+    const open = () => {
+      const rect = img.getBoundingClientRect();
+      // svg <img> may report naturalWidth 0 — fall back to rendered box.
+      // fit mode (the default) never depends on these, only manual zoom does.
+      const width = img.naturalWidth || Math.max(1, Math.round(rect.width));
+      const height = img.naturalHeight || Math.max(1, Math.round(rect.height));
+      onOpen({
+        svg: `<img class="mdv-diagram-viewer__image" src="${escapeViewerAttr(img.src)}" alt="${escapeViewerAttr(img.alt || "")}" />`,
+        width,
+        height,
+      });
+    };
+
+    const onClick = (e: MouseEvent) => {
+      e.preventDefault();
+      open();
+    };
+
+    img.addEventListener("click", onClick);
+    cleanups.push(() => {
+      img.removeEventListener("click", onClick);
+      delete img.dataset.mdvImageViewer;
+    });
+  });
+
+  return () => cleanups.forEach((fn) => fn());
+}
+
 function clampDiagramScale(scale: number): number {
   return Math.min(MAX_DIAGRAM_SCALE, Math.max(MIN_DIAGRAM_SCALE, scale));
 }
@@ -354,4 +399,12 @@ function svgSize(svg: SVGSVGElement): { width: number; height: number } {
   }
   const rect = svg.getBoundingClientRect();
   return { width: Math.max(rect.width, 1), height: Math.max(rect.height, 1) };
+}
+
+function escapeViewerAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/src/components/editor/diagram-viewer.tsx
+++ b/src/components/editor/diagram-viewer.tsx
@@ -309,7 +309,11 @@ export function decorateImages(
   images.forEach((img) => {
     // PlantUML previews carry their own open affordance; mermaid renders as
     // inline <svg>, not <img>, but guard anyway so we never double-bind.
-    if (img.closest(".mdv-plantuml") || img.closest("pre.mdv-mermaid")) return;
+    if (
+      img.closest(".mdv-plantuml") ||
+      img.closest("pre.mdv-mermaid") ||
+      img.closest("a[href]")
+    ) return;
 
     img.dataset.mdvImageViewer = "true";
     img.draggable = false;
@@ -329,6 +333,7 @@ export function decorateImages(
 
     const onClick = (e: MouseEvent) => {
       e.preventDefault();
+      e.stopPropagation();
       open();
     };
 

--- a/src/components/editor/preview.tsx
+++ b/src/components/editor/preview.tsx
@@ -10,6 +10,7 @@ import { basename, isCsvPath } from "@/lib";
 import { CsvPreview } from "./csv-preview";
 import {
   createDiagramViewer,
+  decorateImages,
   decorateMermaidBlocks,
   DiagramViewerOverlay,
   type DiagramViewer,
@@ -199,9 +200,11 @@ export function Preview({ source, filePath }: PreviewProps) {
     if (!articleRef.current || csvPreview) return;
     const cleanupCode = decorateCodeBlocks(articleRef.current);
     const cleanupPlantUml = decoratePlantUmlBlocks(articleRef.current, openDiagramViewer, viewerLabels);
+    const cleanupImages = decorateImages(articleRef.current, openDiagramViewer);
     return () => {
       cleanupCode();
       cleanupPlantUml();
+      cleanupImages();
     };
   }, [html, csvPreview, openDiagramViewer, viewerLabels]);
 

--- a/src/styles/editor/prose.css
+++ b/src/styles/editor/prose.css
@@ -537,6 +537,10 @@
   border: 1px solid var(--border);
 }
 
+.mdv-prose img[data-mdv-image-viewer="true"] {
+  cursor: zoom-in;
+}
+
 .mdv-prose video,
 .mdv-prose audio {
   display: block;

--- a/tests/diagram-viewer.test.ts
+++ b/tests/diagram-viewer.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+import {
+  decorateImages,
+  type DiagramViewerSource,
+} from "../src/components/editor/diagram-viewer";
+
+test("opens decorated images without bubbling into preview handlers", () => {
+  let clickListener: ((event: MouseEvent) => void) | undefined;
+  let prevented = false;
+  let stopped = false;
+  const image = {
+    alt: 'quoted " alt',
+    dataset: {} as DOMStringMap,
+    draggable: true,
+    naturalHeight: 0,
+    naturalWidth: 0,
+    src: "data:image/svg+xml,<svg></svg>",
+    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === "click") clickListener = listener as (event: MouseEvent) => void;
+    },
+    closest: () => null,
+    getBoundingClientRect: () => ({ height: 240.4, width: 320.6 }),
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === "click" && clickListener === listener) clickListener = undefined;
+    },
+  };
+  const root = {
+    querySelectorAll: () => [image],
+  } as unknown as HTMLElement;
+  let opened: DiagramViewerSource | undefined;
+
+  const cleanup = decorateImages(root, (viewer) => {
+    opened = viewer;
+  });
+
+  clickListener?.({
+    preventDefault: () => {
+      prevented = true;
+    },
+    stopPropagation: () => {
+      stopped = true;
+    },
+  } as MouseEvent);
+
+  expect(prevented).toBe(true);
+  expect(stopped).toBe(true);
+  expect(opened).toEqual({
+    svg: '<img class="mdv-diagram-viewer__image" src="data:image/svg+xml,&lt;svg&gt;&lt;/svg&gt;" alt="quoted &quot; alt" />',
+    width: 321,
+    height: 240,
+  });
+  expect(image.dataset.mdvImageViewer).toBe("true");
+  expect(image.draggable).toBe(false);
+
+  cleanup();
+
+  expect(clickListener).toBeUndefined();
+  expect(image.dataset.mdvImageViewer).toBeUndefined();
+});
+
+test("leaves linked images to their anchor navigation", () => {
+  let listenerAdded = false;
+  const link = {};
+  const image = {
+    dataset: {} as DOMStringMap,
+    draggable: true,
+    addEventListener: () => {
+      listenerAdded = true;
+    },
+    closest: (selector: string) => selector === "a[href]" ? link : null,
+  };
+  const root = {
+    querySelectorAll: () => [image],
+  } as unknown as HTMLElement;
+
+  const cleanup = decorateImages(root, () => {
+    throw new Error("linked images must not open the viewer");
+  });
+
+  expect(listenerAdded).toBe(false);
+  expect(image.dataset.mdvImageViewer).toBeUndefined();
+  expect(image.draggable).toBe(true);
+  cleanup();
+});


### PR DESCRIPTION
## summary

- preserve the contributor implementation from #99 and its original authorship
- open ordinary preview images in the existing diagram viewer
- leave images wrapped in Markdown links to their intended navigation
- add focused regression coverage for viewer clicks, linked images, size fallback, escaping, and cleanup

## checks

- `bun test` (26 pass)
- `bun run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Replaces #99 because the contributor organization rejected maintainer branch updates despite maintainer edits being enabled.