### PR TITLE
perf: avoid debouncer file-ID cache walk on watcher creation; incremental watcher registry

### DIFF
--- a/src/hooks/use-folder-watcher.ts
+++ b/src/hooks/use-folder-watcher.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { watch, type UnwatchFn, type WatchEvent } from "@tauri-apps/plugin-fs";
+import { watchImmediate, type UnwatchFn, type WatchEvent } from "@tauri-apps/plugin-fs";
 import { isFilesystemRoot } from "@/lib/storage";
 
 const WATCH_DEBOUNCE_MS = 350;
@@ -20,46 +20,142 @@ export function isDirectoryChangeEvent(event: WatchEvent): boolean {
   return false;
 }
 
+type FolderWatchFn = (
+  path: string,
+  onEvent: (event: WatchEvent) => void,
+) => Promise<UnwatchFn>;
+
+type ScheduleFn = (fn: () => void, ms: number) => unknown;
+type CancelFn = (id: unknown) => void;
+
+export type FolderWatcherController = {
+  /** Reconcile the watched set: watchers are created only for new paths and
+   *  removed only for dropped ones — unchanged paths keep their watcher. */
+  setPaths(paths: readonly string[]): void;
+  dispose(): void;
+};
+
+export type FolderWatcherControllerOptions = {
+  /** Watcher factory — injectable for tests. Defaults to recursive `watchImmediate`. */
+  watch?: FolderWatchFn;
+  debounceMs?: number;
+  isRelevant?: (event: WatchEvent) => boolean;
+  schedule?: ScheduleFn;
+  cancel?: CancelFn;
+};
+
+/**
+ * Watcher registry with change coalescing, extracted from the hook so the
+ * lifecycle logic is unit-testable (see tests/folder-watcher.test.ts).
+ *
+ * Perf-critical details:
+ *  - `watchImmediate` + JS-side coalescing, NOT the plugin's debounced
+ *    `watch`. With `delayMs` set, tauri-plugin-fs (2.5, notify-debouncer-full
+ *    0.6) routes through a debouncer whose file-ID cache walks the entire tree
+ *    at watcher creation on macOS and Windows (`RecommendedCache = FileIdMap`;
+ *    Linux uses `NoCache`), inside a synchronous Tauri command — on large
+ *    roots that froze the app at startup / folder add.
+ *  - Fixed-window coalescing: the first qualifying event schedules a refresh
+ *    `debounceMs` later and further events ride the same window, so sustained
+ *    filesystem churn cannot starve refreshes.
+ *  - Incremental registry: adding a folder creates only the new watcher.
+ *  - A failed watcher registration is evicted so a later reconciliation can
+ *    retry it (guarded against remove/re-add races via promise identity).
+ *  - Tradeoff: raw (uncoalesced) events now cross IPC; the JS window bounds
+ *    the refresh work, not the message volume.
+ */
+export function createFolderWatcherController(
+  onChange: () => void,
+  options: FolderWatcherControllerOptions = {},
+): FolderWatcherController {
+  const watch: FolderWatchFn = options.watch
+    ?? ((path, onEvent) => watchImmediate(path, onEvent, { recursive: true }));
+  const debounceMs = options.debounceMs ?? WATCH_DEBOUNCE_MS;
+  const isRelevant = options.isRelevant ?? isDirectoryChangeEvent;
+  const schedule: ScheduleFn = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+  const cancel: CancelFn = options.cancel
+    ?? ((id) => clearTimeout(id as ReturnType<typeof setTimeout>));
+
+  // path → pending watcher registration; promise identity doubles as the
+  // "is this watcher still current?" token for stale callbacks.
+  const registry = new Map<string, Promise<UnwatchFn | null>>();
+  let timer: unknown = null;
+  let disposed = false;
+
+  const fire = () => {
+    if (timer !== null) return; // window already open — coalesce
+    timer = schedule(() => {
+      timer = null;
+      onChange();
+    }, debounceMs);
+  };
+
+  const add = (path: string) => {
+    // `pending` is referenced inside its own initialiser — safe because the
+    // whole const binding completes synchronously before any event callback
+    // or rejection can run in a later task.
+    const pending: Promise<UnwatchFn | null> = watch(path, (event) => {
+      if (disposed || registry.get(path) !== pending) return; // stale watcher
+      if (isRelevant(event)) fire();
+    }).catch((error: unknown) => {
+      console.warn(`marka.md: failed to watch folder ${path}`, error);
+      // evict so the next reconciliation can retry — unless the path was
+      // removed or re-added (newer registration) in the meantime
+      if (registry.get(path) === pending) registry.delete(path);
+      return null;
+    });
+    registry.set(path, pending);
+  };
+
+  return {
+    setPaths(paths) {
+      if (disposed) return;
+      const wanted = new Set(paths);
+      for (const [path, pending] of registry) {
+        if (wanted.has(path)) continue;
+        registry.delete(path);
+        void pending.then((unwatch) => unwatch?.());
+      }
+      for (const path of wanted) {
+        if (!registry.has(path)) add(path);
+      }
+    },
+    dispose() {
+      disposed = true;
+      for (const pending of registry.values()) {
+        void pending.then((unwatch) => unwatch?.());
+      }
+      registry.clear();
+      if (timer !== null) {
+        cancel(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
 /** Watches each opened root recursively and refreshes the visible tree on structure changes. */
 export function useFolderWatcher(paths: readonly string[], onChange: () => void): void {
   const onChangeRef = useRef(onChange);
-  const pathsKey = paths.join("\0");
+  const controllerRef = useRef<FolderWatcherController | null>(null);
+  const pathsKey = watchableFolderPaths(paths).join("\0");
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
 
+  // controller per mount (not per render) — StrictMode's setup/cleanup/setup
+  // gets a fresh controller each time, so dispose() can be terminal.
   useEffect(() => {
-    let disposed = false;
-    const unwatchers = new Set<UnwatchFn>();
-    const uniquePaths = watchableFolderPaths(paths);
-
-    const start = async () => {
-      for (const path of uniquePaths) {
-        try {
-          const unwatch = await watch(
-            path,
-            (event) => {
-              if (isDirectoryChangeEvent(event)) onChangeRef.current();
-            },
-            { recursive: true, delayMs: WATCH_DEBOUNCE_MS },
-          );
-          if (disposed) {
-            unwatch();
-          } else {
-            unwatchers.add(unwatch);
-          }
-        } catch (error) {
-          console.warn(`marka.md: failed to watch folder ${path}`, error);
-        }
-      }
-    };
-
-    void start();
+    const controller = createFolderWatcherController(() => onChangeRef.current());
+    controllerRef.current = controller;
     return () => {
-      disposed = true;
-      for (const unwatch of unwatchers) unwatch();
-      unwatchers.clear();
+      controllerRef.current = null;
+      controller.dispose();
     };
+  }, []);
+
+  useEffect(() => {
+    controllerRef.current?.setPaths(pathsKey ? pathsKey.split("\0") : []);
   }, [pathsKey]);
 }

--- a/tests/folder-watcher.test.ts
+++ b/tests/folder-watcher.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
+import type { UnwatchFn, WatchEvent } from "@tauri-apps/plugin-fs";
 import {
+  createFolderWatcherController,
   isDirectoryChangeEvent,
   watchableFolderPaths,
 } from "../src/hooks/use-folder-watcher";
@@ -20,4 +22,223 @@ test("ignores file content and access events for tree refreshes", () => {
   expect(isDirectoryChangeEvent({ type: { modify: { kind: "data", mode: "content" } }, paths: [], attrs: null })).toBe(false);
   expect(isDirectoryChangeEvent({ type: { access: { kind: "open", mode: "read" } }, paths: [], attrs: null })).toBe(false);
   expect(isDirectoryChangeEvent({ type: "other", paths: [], attrs: null })).toBe(false);
+});
+
+// --- controller lifecycle -------------------------------------------------
+
+const RELEVANT: WatchEvent = { type: { create: { kind: "folder" } }, paths: [], attrs: null };
+const IRRELEVANT: WatchEvent = { type: { modify: { kind: "data", mode: "content" } }, paths: [], attrs: null };
+
+/** Test double for watchImmediate: records registrations, exposes each
+ *  watcher's event callback, resolves/rejects on demand. */
+function fakeWatchFactory() {
+  type Registration = {
+    path: string;
+    emit: (event: WatchEvent) => void;
+    resolve: () => void;
+    reject: (err: unknown) => void;
+    unwatchCalls: number;
+  };
+  const registrations: Registration[] = [];
+  const watch = (path: string, onEvent: (event: WatchEvent) => void): Promise<UnwatchFn> => {
+    return new Promise<UnwatchFn>((resolve, reject) => {
+      const reg: Registration = {
+        path,
+        emit: onEvent,
+        resolve: () => resolve((() => { reg.unwatchCalls += 1; }) as UnwatchFn),
+        reject,
+        unwatchCalls: 0,
+      };
+      registrations.push(reg);
+    });
+  };
+  return { watch, registrations };
+}
+
+/** Manual scheduler: captured timers fire only when run() is called.
+ *  Counts schedule/cancel calls so tests can pin fixed-window semantics —
+ *  a trailing-edge (cancel-and-reschedule) implementation would show
+ *  scheduleCalls > 1 and cancelCalls > 0 for an event burst. */
+function fakeScheduler() {
+  const timers = new Map<number, () => void>();
+  let nextId = 1;
+  let scheduleCalls = 0;
+  let cancelCalls = 0;
+  return {
+    schedule: (fn: () => void) => {
+      scheduleCalls += 1;
+      const id = nextId++;
+      timers.set(id, fn);
+      return id;
+    },
+    cancel: (id: unknown) => {
+      cancelCalls += 1;
+      timers.delete(id as number);
+    },
+    run: () => {
+      const pending = [...timers.values()];
+      timers.clear();
+      for (const fn of pending) fn();
+    },
+    get size() {
+      return timers.size;
+    },
+    get scheduleCalls() {
+      return scheduleCalls;
+    },
+    get cancelCalls() {
+      return cancelCalls;
+    },
+  };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function makeController(opts?: { onChange?: () => void }) {
+  const { watch, registrations } = fakeWatchFactory();
+  const scheduler = fakeScheduler();
+  let changes = 0;
+  const controller = createFolderWatcherController(
+    () => {
+      changes += 1;
+      opts?.onChange?.();
+    },
+    { watch, schedule: scheduler.schedule, cancel: scheduler.cancel },
+  );
+  return { controller, registrations, scheduler, changes: () => changes };
+}
+
+test("controller reconciles incrementally: unchanged paths keep their watcher", async () => {
+  const { controller, registrations } = makeController();
+  controller.setPaths(["/a"]);
+  expect(registrations.map((r) => r.path)).toEqual(["/a"]);
+  registrations[0].resolve();
+  await tick();
+
+  controller.setPaths(["/a", "/b"]);
+  expect(registrations.map((r) => r.path)).toEqual(["/a", "/b"]); // /a NOT re-registered
+  registrations[1].resolve();
+  await tick();
+
+  controller.setPaths(["/b"]);
+  await tick();
+  expect(registrations[0].unwatchCalls).toBe(1); // /a released exactly once
+  expect(registrations[1].unwatchCalls).toBe(0); // /b untouched
+});
+
+test("controller coalesces event bursts into one refresh per window", async () => {
+  const { controller, registrations, scheduler, changes } = makeController();
+  controller.setPaths(["/a"]);
+  registrations[0].resolve();
+  await tick();
+
+  registrations[0].emit(RELEVANT);
+  registrations[0].emit(RELEVANT);
+  registrations[0].emit(RELEVANT);
+  // fixed window: ONE schedule for the burst, and the original timer is never
+  // cancelled/rescheduled — a trailing-edge debounce would fail both counts
+  expect(scheduler.scheduleCalls).toBe(1);
+  expect(scheduler.cancelCalls).toBe(0);
+  expect(scheduler.size).toBe(1);
+  scheduler.run();
+  expect(changes()).toBe(1);
+
+  registrations[0].emit(RELEVANT); // next window opens after the last fired
+  expect(scheduler.scheduleCalls).toBe(2);
+  expect(scheduler.cancelCalls).toBe(0);
+  scheduler.run();
+  expect(changes()).toBe(2);
+});
+
+test("controller ignores irrelevant events and stale watchers", async () => {
+  const { controller, registrations, scheduler, changes } = makeController();
+  controller.setPaths(["/a"]);
+  registrations[0].resolve();
+  await tick();
+
+  registrations[0].emit(IRRELEVANT);
+  expect(scheduler.size).toBe(0);
+
+  controller.setPaths([]); // remove /a
+  registrations[0].emit(RELEVANT); // late event from the removed watcher
+  expect(scheduler.size).toBe(0);
+  expect(changes()).toBe(0);
+});
+
+test("controller retries a failed registration on the next reconciliation", async () => {
+  const { controller, registrations } = makeController();
+  controller.setPaths(["/a"]);
+  registrations[0].reject(new Error("permission denied"));
+  await tick();
+
+  controller.setPaths(["/a", "/b"]);
+  expect(registrations.map((r) => r.path)).toEqual(["/a", "/a", "/b"]); // /a retried
+});
+
+test("failed registration does not evict a newer watcher for the same path", async () => {
+  const { controller, registrations } = makeController();
+  controller.setPaths(["/a"]);
+  controller.setPaths([]); // remove while first registration still pending
+  controller.setPaths(["/a"]); // re-add — second registration
+  expect(registrations.length).toBe(2);
+
+  registrations[0].reject(new Error("late failure of the removed watcher"));
+  registrations[1].resolve();
+  await tick();
+
+  registrations[1].emit(RELEVANT); // newer watcher must still be live
+  controller.setPaths(["/a"]); // reconcile — must NOT re-register (still current)
+  expect(registrations.length).toBe(2);
+});
+
+test("events from a replaced watcher are ignored; the replacement still fires", async () => {
+  const { controller, registrations, scheduler, changes } = makeController();
+  controller.setPaths(["/a"]);
+  registrations[0].resolve();
+  await tick();
+
+  controller.setPaths([]); // remove /a
+  controller.setPaths(["/a"]); // re-add — new registration for the SAME path
+  registrations[1].resolve();
+  await tick();
+
+  // a registry.has(path)-style guard would wrongly accept this stale emit —
+  // only promise identity distinguishes old from new watcher on the same path
+  registrations[0].emit(RELEVANT);
+  expect(scheduler.size).toBe(0);
+  expect(changes()).toBe(0);
+
+  registrations[1].emit(RELEVANT); // the current watcher still fires
+  scheduler.run();
+  expect(changes()).toBe(1);
+});
+
+test("dispose releases watchers, cancels timers, and goes terminal", async () => {
+  const { controller, registrations, scheduler, changes } = makeController();
+  controller.setPaths(["/a"]);
+  registrations[0].resolve();
+  await tick();
+
+  registrations[0].emit(RELEVANT);
+  expect(scheduler.size).toBe(1);
+
+  controller.dispose();
+  expect(scheduler.size).toBe(0); // pending refresh cancelled
+  await tick();
+  expect(registrations[0].unwatchCalls).toBe(1);
+
+  registrations[0].emit(RELEVANT); // events after dispose are inert
+  expect(scheduler.size).toBe(0);
+  controller.setPaths(["/b"]); // setPaths after dispose is inert
+  expect(registrations.length).toBe(1);
+  expect(changes()).toBe(0);
+});
+
+test("unwatch runs even when the path is removed before registration resolves", async () => {
+  const { controller, registrations } = makeController();
+  controller.setPaths(["/a"]);
+  controller.setPaths([]); // removed while pending
+  registrations[0].resolve(); // native watcher comes up late
+  await tick();
+  expect(registrations[0].unwatchCalls).toBe(1); // still released
 });


### PR DESCRIPTION
Fixes #121.

*Transparency up front: I hit this bug as a user; the root-cause tracing, fix, and tests were done with AI assistance (Claude — see the commit trailer), with the mechanism claims verified against the vendored crate sources cited below. I've verified the behaviour on my own machine (macOS, Apple Silicon) and I'm happy to answer questions — same tooling in the loop.*

**What changed**

`use-folder-watcher.ts` + tests. Three behavior changes, stated explicitly:

1. **`watchImmediate` instead of debounced `watch()`** — with `delayMs`, tauri-plugin-fs routes through notify-debouncer-full, whose file-ID cache walks the entire tree (a `stat`/handle-open per entry) at `debouncer.watch()` time on macOS and Windows, inside a synchronous Tauri command on the main thread. `watchImmediate` skips the debouncer entirely. Event schemas are identical (both branches serialize the inner `notify::Event`), so `isDirectoryChangeEvent` filters both the same way — refresh *timing* changes, per point 2.
2. **Coalescing moves to JS with different semantics** — previously the Rust debouncer aged each event ~350 ms per path; now the first qualifying event schedules a refresh 350 ms later on a fixed window shared across roots, and further events ride that window instead of resetting it (a naive trailing-edge debounce would starve under sustained churn — there's a test pinning this). Under a responsive event loop that approximately bounds refreshes to ~3/sec during continuous writes while keeping the tree from going stale.
3. **Incremental watcher registry** — the watcher lifecycle is extracted into a small dependency-injectable controller; adding/removing a folder now touches only that folder's watcher instead of tearing down and re-creating all of them. A failed registration is evicted so a later reconciliation retries it (previously the recreate-all behavior provided implicit retry; the registry keeps that property explicitly).

**Testing**

- Automated: 8 new unit tests over the controller (incremental reconciliation, burst coalescing with schedule/cancel-count assertions, stale-watcher suppression incl. remove/re-add identity, failure retry, dispose lifecycle, unwatch of late-resolving registrations) — `bun test` 55 pass. The watcher lifecycle previously had no unit coverage and no seam for injecting fakes; the extracted controller provides both.
- Manual (macOS, Apple Silicon): with a ~10k-file root, startup and add-folder no longer beachball; external create/rename/delete still refresh the tree. I have not measured Windows/Linux — on Linux the removed cost doesn't exist (`NoCache`), so this change mainly benefits macOS/Windows; the incremental registry benefits all platforms.

**Tradeoff / limitation**

Raw events now cross IPC uncoalesced during bulk writes; the JS window bounds refresh work but not message volume. If that ever shows up in practice, the durable fix is upstream in tauri-plugin-fs (async command / opt-out of the cache).

`watchableFolderPaths` / `isDirectoryChangeEvent` exports are unchanged.
