### PR TITLE
fix: publish updater manifest with public download URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,46 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
     steps:
+      - name: checkout release tooling
+        uses: actions/checkout@v7
+
+      - name: normalize updater manifest URLs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          WORK_DIR="$RUNNER_TEMP/latest-json"
+          mkdir -p "$WORK_DIR"
+
+          LATEST_ASSET_NAME=$(gh api "repos/${{ github.repository }}/releases/tags/${{ env.RELEASE_TAG }}" \
+            --jq '[.assets[] | select(.name == "latest.json") | .name][0] // ""')
+
+          if [ "$LATEST_ASSET_NAME" != "latest.json" ]; then
+            echo "no latest.json asset found for ${{ env.RELEASE_TAG }} — skipping updater manifest normalization"
+            exit 0
+          fi
+
+          gh release download "${{ env.RELEASE_TAG }}" \
+            --repo "${{ github.repository }}" \
+            --pattern latest.json \
+            --dir "$WORK_DIR"
+
+          gh api "repos/${{ github.repository }}/releases/tags/${{ env.RELEASE_TAG }}" \
+            --jq '.assets | map({ name, url, browser_download_url })' \
+            > "$WORK_DIR/release-assets.json"
+
+          node scripts/normalize-latest-json.mjs \
+            "$WORK_DIR/latest.json" \
+            "$WORK_DIR/release-assets.json" \
+            "$WORK_DIR/latest.normalized.json"
+
+          gh release upload "${{ env.RELEASE_TAG }}" \
+            "$WORK_DIR/latest.normalized.json#latest.json" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
       - name: publish draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,6 +18,7 @@ Use this after the version bump commit is ready and before calling the release d
 - [ ] GitHub `release` workflow passes on the tag.
 - [ ] GitHub release is public, latest, and has macOS, Windows, Linux, signature, and `latest.json` assets.
 - [ ] Download `latest.json` and confirm the version, release notes, platform URLs, and signatures are present.
+- [ ] Confirm `latest.json` platform URLs use public `https://github.com/.../releases/download/...` links, not `https://api.github.com/.../releases/assets/...` REST API links.
 
 ## site refresh
 

--- a/scripts/normalize-latest-json.mjs
+++ b/scripts/normalize-latest-json.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const GITHUB_RELEASE_ASSET_API_URL =
+  /^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/releases\/assets\/\d+$/;
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function getReleaseAssets(releaseAssets) {
+  if (Array.isArray(releaseAssets)) {
+    return releaseAssets;
+  }
+
+  if (releaseAssets && typeof releaseAssets === "object" && Array.isArray(releaseAssets.assets)) {
+    return releaseAssets.assets;
+  }
+
+  throw new TypeError("release assets must be an array or an object with an assets array");
+}
+
+export function normalizeLatestJsonUrls(latestJson, releaseAssets) {
+  if (!latestJson || typeof latestJson !== "object" || Array.isArray(latestJson)) {
+    throw new TypeError("latest.json must be a JSON object");
+  }
+
+  const downloadUrlByApiUrl = new Map();
+  for (const asset of getReleaseAssets(releaseAssets)) {
+    if (!asset || typeof asset !== "object") {
+      continue;
+    }
+
+    if (typeof asset.url === "string" && typeof asset.browser_download_url === "string") {
+      downloadUrlByApiUrl.set(asset.url, asset.browser_download_url);
+    }
+  }
+
+  const manifest = cloneJson(latestJson);
+  const platforms = manifest.platforms;
+  if (!platforms || typeof platforms !== "object" || Array.isArray(platforms)) {
+    return { manifest, changed: 0 };
+  }
+
+  const unresolvedRestUrls = [];
+  let changed = 0;
+
+  for (const [platformName, platform] of Object.entries(platforms)) {
+    if (!platform || typeof platform !== "object" || Array.isArray(platform) || typeof platform.url !== "string") {
+      continue;
+    }
+
+    const publicDownloadUrl = downloadUrlByApiUrl.get(platform.url);
+    if (publicDownloadUrl) {
+      platform.url = publicDownloadUrl;
+      changed += 1;
+      continue;
+    }
+
+    if (GITHUB_RELEASE_ASSET_API_URL.test(platform.url)) {
+      unresolvedRestUrls.push(`${platformName}: ${platform.url}`);
+    }
+  }
+
+  if (unresolvedRestUrls.length > 0) {
+    throw new Error(`latest.json still contains unmapped GitHub REST asset URLs:\n${unresolvedRestUrls.join("\n")}`);
+  }
+
+  return { manifest, changed };
+}
+
+async function main() {
+  const [latestJsonPath, releaseAssetsPath, outputPath] = process.argv.slice(2);
+  if (!latestJsonPath || !releaseAssetsPath || !outputPath) {
+    console.error("usage: normalize-latest-json.mjs <latest.json> <release-assets.json> <output.json>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const latestJson = JSON.parse(await readFile(latestJsonPath, "utf8"));
+  const releaseAssets = JSON.parse(await readFile(releaseAssetsPath, "utf8"));
+  const { manifest, changed } = normalizeLatestJsonUrls(latestJson, releaseAssets);
+
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`normalized ${changed} latest.json platform URL${changed === 1 ? "" : "s"}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/normalize-latest-json.test.mjs
+++ b/tests/normalize-latest-json.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeLatestJsonUrls } from "../scripts/normalize-latest-json.mjs";
+
+test("rewrites updater platform URLs to public release downloads", () => {
+  const latestJson = {
+    version: "1.7.1",
+    platforms: {
+      "darwin-aarch64": {
+        signature: "signature-a",
+        url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491082498",
+      },
+      "darwin-aarch64-app": {
+        signature: "signature-a",
+        url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491082498",
+      },
+      "windows-x86_64": {
+        signature: "signature-w",
+        url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491085944",
+      },
+      external: {
+        signature: "signature-external",
+        url: "https://downloads.example.test/marka.md.tar.gz",
+      },
+    },
+  };
+
+  const { manifest, changed } = normalizeLatestJsonUrls(latestJson, [
+    {
+      name: "marka.md_1.7.1_aarch64.app.tar.gz",
+      url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491082498",
+      browser_download_url:
+        "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_aarch64.app.tar.gz",
+    },
+    {
+      name: "marka.md_1.7.1_x64_en-US.msi",
+      url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491085944",
+      browser_download_url:
+        "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_x64_en-US.msi",
+    },
+  ]);
+
+  assert.equal(changed, 3);
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].url,
+    "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_aarch64.app.tar.gz",
+  );
+  assert.equal(
+    manifest.platforms["darwin-aarch64-app"].url,
+    "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_aarch64.app.tar.gz",
+  );
+  assert.equal(
+    manifest.platforms["windows-x86_64"].url,
+    "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_x64_en-US.msi",
+  );
+  assert.equal(manifest.platforms.external.url, "https://downloads.example.test/marka.md.tar.gz");
+  assert.equal(
+    latestJson.platforms["darwin-aarch64"].url,
+    "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491082498",
+  );
+});
+
+test("throws when a GitHub REST asset URL has no matching release asset", () => {
+  assert.throws(
+    () =>
+      normalizeLatestJsonUrls(
+        {
+          platforms: {
+            "linux-x86_64": {
+              signature: "signature-l",
+              url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491085196",
+            },
+          },
+        },
+        [],
+      ),
+    /unmapped GitHub REST asset URLs/,
+  );
+});
+
+test("accepts the full release object shape returned by the GitHub API", () => {
+  const { manifest, changed } = normalizeLatestJsonUrls(
+    {
+      platforms: {
+        "linux-x86_64": {
+          signature: "signature-l",
+          url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491085196",
+        },
+      },
+    },
+    {
+      assets: [
+        {
+          url: "https://api.github.com/repos/mattenarle10/markamd/releases/assets/491085196",
+          browser_download_url:
+            "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_amd64.AppImage",
+        },
+      ],
+    },
+  );
+
+  assert.equal(changed, 1);
+  assert.equal(
+    manifest.platforms["linux-x86_64"].url,
+    "https://github.com/mattenarle10/markamd/releases/download/v1.7.1/marka.md_1.7.1_amd64.AppImage",
+  );
+});


### PR DESCRIPTION
Fixes #124.

## What changed

- Add a small release-tooling script that rewrites generated `latest.json` platform URLs from GitHub REST release asset API endpoints to the matching public `releases/download` URLs.
- Run that normalization in the `publish-release` job before the draft release is made public, then re-upload `latest.json` with `--clobber`.
- Leave unsigned/manual releases alone when no `latest.json` asset exists.
- Add focused coverage for duplicate platform entries, missing asset mappings, and the GitHub API release object shape.
- Add a release-checklist reminder to verify updater manifest URL shape after tagging.

## Why

Tauri's generated updater manifest can point package URLs at `https://api.github.com/repos/.../releases/assets/<id>`. Installed clients fetch those URLs without a token, so a shared public IP can exhaust GitHub's unauthenticated REST API quota and make update installation fail with HTTP 403 even though the public release asset itself is still downloadable.

Keeping the manifest on public `https://github.com/.../releases/download/...` URLs avoids the REST API quota path and fixes the release pipeline instead of requiring a client token or hiding the updater error.

## Verification

- `node --test tests/normalize-latest-json.test.mjs`
- Dry run against the current public `v1.7.1` release manifest and asset list: normalized 11 platform URLs, 0 `api.github.com` REST asset URLs remaining, 11 public release download URLs
- `node --check scripts/normalize-latest-json.mjs && node --check tests/normalize-latest-json.test.mjs`
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `git diff --check`

Not run locally: `cargo check --release` because this machine does not have a Rust toolchain installed; this PR does not change Rust code.
