### PR TITLE
fix: keep active-file reloads on immediate watcher events

### DIFF
--- a/src/hooks/use-file-watcher.ts
+++ b/src/hooks/use-file-watcher.ts
@@ -1,5 +1,7 @@
-import { useEffect } from "react";
-import { watch, type UnwatchFn, type WatchEvent } from "@tauri-apps/plugin-fs";
+import { useEffect, useRef } from "react";
+import { watchImmediate, type UnwatchFn, type WatchEvent } from "@tauri-apps/plugin-fs";
+
+const WATCH_DEBOUNCE_MS = 350;
 
 export function isFileContentChangeEvent(event: WatchEvent): boolean {
   if (event.type === "any") return true;
@@ -11,34 +13,117 @@ export function isFileContentChangeEvent(event: WatchEvent): boolean {
   return false;
 }
 
+type FileWatchFn = (
+  path: string,
+  onEvent: (event: WatchEvent) => void,
+) => Promise<UnwatchFn>;
+
+type ScheduleFn = (fn: () => void, ms: number) => unknown;
+type CancelFn = (id: unknown) => void;
+
+export type FileWatcherController = {
+  setPath(path: string | null): void;
+  dispose(): void;
+};
+
+export type FileWatcherControllerOptions = {
+  watch?: FileWatchFn;
+  debounceMs?: number;
+  isRelevant?: (event: WatchEvent) => boolean;
+  schedule?: ScheduleFn;
+  cancel?: CancelFn;
+};
+
+export function createFileWatcherController(
+  onChange: () => void,
+  options: FileWatcherControllerOptions = {},
+): FileWatcherController {
+  const watch: FileWatchFn = options.watch ?? ((path, onEvent) => watchImmediate(path, onEvent));
+  const debounceMs = options.debounceMs ?? WATCH_DEBOUNCE_MS;
+  const isRelevant = options.isRelevant ?? isFileContentChangeEvent;
+  const schedule: ScheduleFn = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+  const cancel: CancelFn = options.cancel
+    ?? ((id) => clearTimeout(id as ReturnType<typeof setTimeout>));
+
+  let watchedPath: string | null = null;
+  let pending: Promise<UnwatchFn | null> | null = null;
+  let timer: unknown = null;
+  let disposed = false;
+
+  const cancelPendingChange = () => {
+    if (timer === null) return;
+    cancel(timer);
+    timer = null;
+  };
+
+  const fire = () => {
+    if (timer !== null) return;
+    timer = schedule(() => {
+      timer = null;
+      onChange();
+    }, debounceMs);
+  };
+
+  const clearWatcher = () => {
+    const current = pending;
+    watchedPath = null;
+    pending = null;
+    cancelPendingChange();
+    void current?.then((unwatch) => unwatch?.());
+  };
+
+  const addWatcher = (path: string) => {
+    // `registration` is referenced inside its own initializer; the callback
+    // can only run after this synchronous assignment completes.
+    const registration: Promise<UnwatchFn | null> = watch(path, (event) => {
+      if (disposed || pending !== registration) return;
+      if (isRelevant(event)) fire();
+    }).catch((error: unknown) => {
+      console.warn(`marka.md: failed to watch file ${path}`, error);
+      if (pending === registration) {
+        watchedPath = null;
+        pending = null;
+      }
+      return null;
+    });
+    watchedPath = path;
+    pending = registration;
+  };
+
+  return {
+    setPath(path) {
+      if (disposed || path === watchedPath) return;
+      clearWatcher();
+      if (path) addWatcher(path);
+    },
+    dispose() {
+      disposed = true;
+      clearWatcher();
+    },
+  };
+}
+
 /**
  * Watches the active file through Tauri's native filesystem watcher.
  */
 export function useFileWatcher(path: string | null, onChange: () => void): void {
+  const onChangeRef = useRef(onChange);
+  const controllerRef = useRef<FileWatcherController | null>(null);
+
   useEffect(() => {
-    if (!path) return;
-    let disposed = false;
-    let unwatch: UnwatchFn | null = null;
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
-    void watch(
-      path,
-      (event) => {
-        if (isFileContentChangeEvent(event)) onChange();
-      },
-      { delayMs: 350 },
-    )
-      .then((stop) => {
-        if (disposed) stop();
-        else unwatch = stop;
-      })
-      .catch((error) => {
-        console.warn(`marka.md: failed to watch file ${path}`, error);
-      });
-
+  useEffect(() => {
+    const controller = createFileWatcherController(() => onChangeRef.current());
+    controllerRef.current = controller;
     return () => {
-      disposed = true;
-      unwatch?.();
-      unwatch = null;
+      controllerRef.current = null;
+      controller.dispose();
     };
-  }, [path, onChange]);
+  }, []);
+
+  useEffect(() => {
+    controllerRef.current?.setPath(path);
+  }, [path]);
 }

--- a/tests/file-watcher.test.ts
+++ b/tests/file-watcher.test.ts
@@ -1,5 +1,20 @@
 import { expect, test } from "bun:test";
-import { isFileContentChangeEvent } from "../src/hooks/use-file-watcher";
+import type { UnwatchFn, WatchEvent } from "@tauri-apps/plugin-fs";
+import {
+  createFileWatcherController,
+  isFileContentChangeEvent,
+} from "../src/hooks/use-file-watcher";
+
+const CONTENT_CHANGE: WatchEvent = {
+  type: { modify: { kind: "data", mode: "content" } },
+  paths: [],
+  attrs: null,
+};
+const ACCESS_CHANGE: WatchEvent = {
+  type: { access: { kind: "open", mode: "read" } },
+  paths: [],
+  attrs: null,
+};
 
 test("reloads for file create, remove, and content changes", () => {
   expect(isFileContentChangeEvent({ type: { create: { kind: "file" } }, paths: [], attrs: null })).toBe(true);
@@ -11,4 +26,128 @@ test("ignores access, metadata, and unrelated events", () => {
   expect(isFileContentChangeEvent({ type: { access: { kind: "open", mode: "read" } }, paths: [], attrs: null })).toBe(false);
   expect(isFileContentChangeEvent({ type: { modify: { kind: "metadata", mode: "permissions" } }, paths: [], attrs: null })).toBe(false);
   expect(isFileContentChangeEvent({ type: "other", paths: [], attrs: null })).toBe(false);
+});
+
+function fakeWatchFactory() {
+  const registrations: Array<{
+    path: string;
+    emit: (event: WatchEvent) => void;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+    unwatchCalls: number;
+  }> = [];
+
+  const watch = (path: string, onEvent: (event: WatchEvent) => void): Promise<UnwatchFn> => {
+    return new Promise<UnwatchFn>((resolve, reject) => {
+      const reg = {
+        path,
+        emit: onEvent,
+        resolve: () => resolve((() => { reg.unwatchCalls += 1; }) as UnwatchFn),
+        reject,
+        unwatchCalls: 0,
+      };
+      registrations.push(reg);
+    });
+  };
+
+  return { watch, registrations };
+}
+
+function fakeScheduler() {
+  const tasks = new Map<number, () => void>();
+  let nextId = 1;
+
+  return {
+    schedule(fn: () => void) {
+      const id = nextId;
+      nextId += 1;
+      tasks.set(id, fn);
+      return id;
+    },
+    cancel(id: unknown) {
+      tasks.delete(id as number);
+    },
+    runAll() {
+      const pending = Array.from(tasks.entries());
+      tasks.clear();
+      for (const [, fn] of pending) fn();
+    },
+    get size() {
+      return tasks.size;
+    },
+  };
+}
+
+function flushAsyncCleanup(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("coalesces active file content changes and ignores access events", () => {
+  const { watch, registrations } = fakeWatchFactory();
+  const scheduler = fakeScheduler();
+  let reloads = 0;
+
+  const controller = createFileWatcherController(() => { reloads += 1; }, {
+    watch,
+    schedule: scheduler.schedule,
+    cancel: scheduler.cancel,
+  });
+
+  controller.setPath("/notes/today.md");
+  registrations[0].emit(CONTENT_CHANGE);
+  registrations[0].emit(CONTENT_CHANGE);
+  registrations[0].emit(ACCESS_CHANGE);
+
+  expect(scheduler.size).toBe(1);
+  scheduler.runAll();
+  expect(reloads).toBe(1);
+});
+
+test("keeps stale file watcher events from reloading the new active file", async () => {
+  const { watch, registrations } = fakeWatchFactory();
+  const scheduler = fakeScheduler();
+  let reloads = 0;
+
+  const controller = createFileWatcherController(() => { reloads += 1; }, {
+    watch,
+    schedule: scheduler.schedule,
+    cancel: scheduler.cancel,
+  });
+
+  controller.setPath("/notes/old.md");
+  controller.setPath("/notes/new.md");
+
+  registrations[0].emit(CONTENT_CHANGE);
+  registrations[1].emit(CONTENT_CHANGE);
+
+  scheduler.runAll();
+  expect(reloads).toBe(1);
+
+  registrations[0].resolve();
+  await flushAsyncCleanup();
+  expect(registrations[0].unwatchCalls).toBe(1);
+});
+
+test("dispose releases the active file watcher and cancels pending reloads", async () => {
+  const { watch, registrations } = fakeWatchFactory();
+  const scheduler = fakeScheduler();
+  let reloads = 0;
+
+  const controller = createFileWatcherController(() => { reloads += 1; }, {
+    watch,
+    schedule: scheduler.schedule,
+    cancel: scheduler.cancel,
+  });
+
+  controller.setPath("/notes/today.md");
+  registrations[0].emit(CONTENT_CHANGE);
+  expect(scheduler.size).toBe(1);
+
+  controller.dispose();
+  scheduler.runAll();
+  expect(reloads).toBe(0);
+
+  registrations[0].resolve();
+  await flushAsyncCleanup();
+  expect(registrations[0].unwatchCalls).toBe(1);
 });


### PR DESCRIPTION
Fixes #125.

## Summary

- Move the active-file reload watcher from Tauri's debounced `watch(..., { delayMs })` helper to `watchImmediate`.
- Coalesce active-file change events in JavaScript with the same fixed-window approach used by the folder watcher.
- Keep stale watcher events from an old active file from reloading the newly selected file.
- Add focused tests for content-event coalescing, stale watcher cleanup, and dispose behavior.

## Why

The folder watcher already avoids the plugin debouncer because recent watcher work found that path can be expensive and fragile on macOS/Windows. The active-file reload path still used the debounced helper, so this PR moves it to the same immediate-event pattern while preserving the existing 350ms coalescing behavior.

That keeps external edits responsive without depending on the native debouncer path, and it makes the watcher lifecycle testable so active-file switching cannot leave old events pointed at the current editor buffer.

## Verification

- `bun test tests/file-watcher.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

## Notes

I could not run a macOS Apple Silicon desktop smoke test from this Linux environment, so the validation here is focused on the watcher lifecycle and existing frontend gates. No Rust code or UI behavior was changed.
