### PR TITLE
chore(release): prepare v1.7.2

### DIFF
--- a/docs/release-notes/v1.7.2.md
+++ b/docs/release-notes/v1.7.2.md
@@ -1,0 +1,25 @@
+# v1.7.2
+
+v1.7.2 is a stability patch for updater downloads, file watching, Linux startup, and preview workflows.
+
+## fixed
+
+- Rewrote generated updater manifest URLs to public GitHub release download URLs so update downloads do not depend on unauthenticated REST API quota (#124, #126).
+- Kept active-file reloads responsive by using immediate watcher events with JavaScript-side coalescing and stale watcher cleanup (#125, #127).
+- Avoided the Tauri AppImage X11 backend default on Wayland sessions and kept the WebKit DMA-BUF fallback for affected Linux systems (#107, #128).
+
+## improved
+
+- Added local-asset HTML rendering to quick previews (#130).
+- Documented Arch Linux AUR installation (#131).
+- Updated markdown-it to 15.0.0 (#129).
+
+## thanks
+
+- Thanks to @11suixing11 for the updater, watcher, and Linux fixes.
+- Thanks to the contributors behind the preview and documentation improvements.
+
+## notes
+
+- Signed updater artifacts remain enabled.
+- The release workflow normalizes `latest.json` platform URLs before publishing.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2095,7 +2095,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.7.1"
+version = "1.7.2"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
   "mainBinaryName": "marka.md",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## summary
- bump the application, Tauri shell, and updater config to v1.7.2
- add public release notes for the merged updater, watcher, Linux, preview, docs, and dependency changes

## validation
- `bun test`
- `bun run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml --release --locked`

Closes #107.