### PR TITLE
docs: mark v1.7.2 release complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 - [x] v1.6.0 workflow: separate preview windows, command-palette markdown insertions, and Traditional Chinese localization
 - [x] v1.6.1 workflow: automatic folder monitoring, native file watching, and lazy markdown highlighting
 - [x] v1.7.1 workflow: quick file previews, app-wide zoom, and faster folder watching
-- [ ] v1.7.2 patch: public updater downloads, active-file reload reliability, and Linux Wayland AppImage startup
+- [x] v1.7.2 patch: public updater downloads, active-file reload reliability, and Linux Wayland AppImage startup
 - [ ] next: native/silent PDF generation
 - [ ] next: context handoff presets for bring-your-own-ai workflows, starting with markdown and XML-tag bundle formats
 


### PR DESCRIPTION
Mark the v1.7.2 roadmap item complete now that the GitHub release workflow and site notification both passed.