### PR TITLE
chore(release): prepare v1.7.3

### DIFF
--- a/docs/release-notes/v1.7.3.md
+++ b/docs/release-notes/v1.7.3.md
@@ -1,0 +1,21 @@
+# v1.7.3
+
+v1.7.3 adds a dedicated settings surface for configuring marka.md without interrupting the writing workflow.
+
+## added
+
+- Added a settings button beside help in the status bar.
+- Added `cmd+,` on macOS and `ctrl+,` on other platforms to open settings.
+- Added appearance, editor, reading, startup, and language preferences in one overlay.
+- Added smooth controls for writing font size, writing line spacing, reading size, reading width, and preview font size.
+- Added a reset action for returning preferences to their defaults.
+
+## improved
+
+- Kept theme selection in the theme menu while moving general preferences into settings.
+- Added settings and keyboard shortcut guidance to the README, help content, and translations.
+
+## notes
+
+- Preferences remain local to the app.
+- Signed updater artifacts remain enabled.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marka-md",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2095,7 +2095,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marka"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marka"
-version = "1.7.2"
+version = "1.7.3"
 description = "marka.md — a local markdown editor for the notes you share with ai"
 authors = ["Matt Enarle"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "marka.md",
   "mainBinaryName": "marka.md",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "identifier": "com.mattenarle.markamd",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## summary
- bump app versions to 1.7.3
- add public v1.7.3 release notes for the settings surface

## validation
- bun test
- bun run build
- cargo check --release --manifest-path src-tauri/Cargo.toml
- git diff --check