### PR TITLE
docs: record release and local workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,18 @@
 - `bun test` runs focused unit tests.
 - `bun run build` runs TypeScript and Vite build.
 - `cargo check --manifest-path src-tauri/Cargo.toml` checks the Rust shell.
+- `cargo check --release --manifest-path src-tauri/Cargo.toml` checks the release profile used by CI.
+- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` checks Rust formatting without changing files.
 - `bun run tauri dev` starts the desktop app during UI testing.
+
+## local github workflow
+
+- Keep the user's primary checkout available. Use a separate clean checkout for branch, PR, and release work.
+- Keep one focused branch per behavior change and run the app from that checkout so screenshots test the branch being changed.
+- If another dev server occupies port `1420`, use a temporary Vite/Tauri port override and record the port used for testing.
+- Before merging, verify the PR author and active GitHub account, inspect comments and reviews, and wait for both `typecheck` and `rust-check` to pass.
+- For a release, merge the feature PR first, merge a separate version-bump PR, tag the exact merged `origin/main` commit, and watch the tag's `release` workflow through publication. Confirm the GitHub release is public and latest with signed platform assets and `latest.json`.
+- Check `https://markamd.vercel.app/` and `/changelog/` after publishing. The site fetches release data at build time; if it is stale, use the site repository's normal Vercel deploy path rather than changing app release metadata.
 
 ## release/update notes
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Per-release detail lives on the [changelog](https://markamd.vercel.app/changelog
 - [x] v1.6.1 workflow: automatic folder monitoring, native file watching, and lazy markdown highlighting
 - [x] v1.7.1 workflow: quick file previews, app-wide zoom, and faster folder watching
 - [x] [v1.7.2 patch](docs/release-notes/v1.7.2.md): public updater downloads, active-file reload reliability, and Linux Wayland AppImage startup
+- [x] [v1.7.3 settings](docs/release-notes/v1.7.3.md): dedicated preferences surface, keyboard access, and smooth writing/reading controls
 - [ ] next: native/silent PDF generation
 - [ ] next: context handoff presets for bring-your-own-ai workflows, starting with markdown and XML-tag bundle formats
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,6 +6,7 @@ Use this after the version bump commit is ready and before calling the release d
 
 - [ ] App versions match in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock`.
 - [ ] Release notes exist at `docs/release-notes/vX.Y.Z.md`.
+- [ ] Merge the feature PR first, then make the version bump in a separate release PR based on `origin/main`.
 - [ ] `bun test` passes.
 - [ ] `bun run build` passes.
 - [ ] `cargo check --release` passes from `src-tauri`.
@@ -21,12 +22,16 @@ Use this after the version bump commit is ready and before calling the release d
 - [ ] Download `latest.json` and confirm the version, release notes, platform URLs, and signatures are present.
 - [ ] Confirm `latest.json` platform URLs use public `https://github.com/.../releases/download/...` links, not `https://api.github.com/.../releases/assets/...` REST API links.
 
+The tag must resolve to the same commit as `origin/main` (`git rev-parse vX.Y.Z^{}` versus `git rev-parse origin/main`). Use the repository's configured GitHub account for PR and release operations, and verify the author before merging.
+
 ## site refresh
 
 - [ ] Confirm the `notify-site` job ran or the `VERCEL_DEPLOY_HOOK` secret is configured.
 - [ ] Check `https://markamd.vercel.app/` shows the new version in download links, schema, footer, and release section.
 - [ ] Check `https://markamd.vercel.app/changelog/` starts with the new release notes.
 - [ ] If the site is stale, rebuild/redeploy `markamd-site` or push a small site refresh commit.
+
+The landing site reads the latest GitHub release and repository stats at build time. Check the live homepage and `/changelog/` before making a site change; a successful release does not guarantee that a Vercel deploy hook is configured.
 
 ## triage
 


### PR DESCRIPTION
## summary
- document the verified local PR and release workflow
- add v1.7.3 to the public roadmap
- clarify live site and Vercel refresh checks

## validation
- git diff --check